### PR TITLE
Changed build dependencies to reduced requirements and re-added run dependencies 

### DIFF
--- a/quantecon/meta.yaml
+++ b/quantecon/meta.yaml
@@ -28,6 +28,7 @@ source:
 requirements:
   build:
     - python
+    - setuptools
       #    - numpy
       #    - scipy
       #    - pandas
@@ -35,10 +36,10 @@ requirements:
 
   run:
     - python
-      #    - numpy
-      #    - scipy
-      #    - pandas
-      #    - matplotlib
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib
 
 test:
   # Python imports


### PR DESCRIPTION
Conda build sets up a new build environment `envs/_build/`
build: only really requires python and setuptools and is a reduced set of requirments
run: requires the libraries used in the project. 

```
conda update conda  
conda update anaconda
```

should be run prior to `conda install quantecon`
