### PR TITLE
BUG: numpy broadcasting error in asset pricing

### DIFF
--- a/quantecon/asset_pricing.py
+++ b/quantecon/asset_pricing.py
@@ -21,21 +21,20 @@ class AssetPrices:
         Parameters
         ==========
         beta : float
-            discount factor 
+            discount factor
 
         P : array_like
-            transition matrix 
-            
+            transition matrix
+
         s : array_like
-            growth rate of consumption 
+            growth rate of consumption
 
         gamma : float
-            coefficient of risk aversion 
+            coefficient of risk aversion
         '''
         self.beta, self.gamma = beta, gamma
-        self.P, self.s = [np.atleast_2d(x) for x in P, s]
+        self.P, self.s = P, s
         self.n = self.P.shape[0]
-        self.s.shape = self.n, 1
 
     def tree_price(self):
         '''
@@ -50,7 +49,7 @@ class AssetPrices:
         O = np.ones(self.n)
         v = beta * solve(I - beta * P_tilde, P_tilde.dot(O))
         return v
-        
+
     def consol_price(self, zeta):
         '''
         Computes price of a consol bond with payoff zeta
@@ -69,7 +68,7 @@ class AssetPrices:
         O = np.ones(self.n)
         p_bar = beta * solve(I - beta * P_check, P_check.dot(zeta * O))
         return p_bar
-        
+
     def call_option(self, zeta, p_s, T=[], epsilon=1e-8):
         '''
         Computes price of a call option on a consol bond with payoff zeta
@@ -80,10 +79,10 @@ class AssetPrices:
             coupon of the console
 
         p_s : float
-            strike price 
+            strike price
 
-        T : list of integers 
-            length of option 
+        T : list of integers
+            length of option
 
         epsilon : float
             tolerance for infinite horizon problem
@@ -103,11 +102,11 @@ class AssetPrices:
                 w_bars[t] = w_bar
             # == Maximize across columns == #
             to_stack = (beta*P_check.dot(w_bar), v_bar-p_s)
-            w_bar_new = np.amax(np.vstack(to_stack), axis = 0 ) 
+            w_bar_new = np.amax(np.vstack(to_stack), axis = 0 )
             # == Find maximal difference of each component == #
-            error = np.amax(np.abs(w_bar-w_bar_new)) 
+            error = np.amax(np.abs(w_bar-w_bar_new))
             # == Update == #
             w_bar = w_bar_new
             t += 1
-        
+
         return w_bar, w_bars


### PR DESCRIPTION
There was a bug in the asset pricing code.

In the `__init__` function for the `AssetPrices` class we were making the state space `s` be an n by 1 array. 

When we tried to compute `P_tilde` and `P_check`, `s` being a two-dimensional array caused the broadcasting to be wrong.

We need to be computing `P_tilde[i, j] = P[i, j] * s[j]**(1 - gamma)`, but with a 2-dimensional s we were actually computing `P_tilde[i, j] = P[i, j] * s[i]**(1 - gamma)`.

Just keeping s as a one-dimensional input fixes the problem.

---

As an example (I did this for my own benefit to make sure I wasn't crazy), consider the following output I got from an ipython session:

```
In [9]: s
Out[9]: array([ 1.05 ,  1.025,  1.   ,  0.975,  0.95 ])

In [10]: P
Out[10]:
array([[ 0.95  ,  0.0125,  0.0125,  0.0125,  0.0125],
       [ 0.0125,  0.95  ,  0.0125,  0.0125,  0.0125],
       [ 0.0125,  0.0125,  0.95  ,  0.0125,  0.0125],
       [ 0.0125,  0.0125,  0.0125,  0.95  ,  0.0125],
       [ 0.0125,  0.0125,  0.0125,  0.0125,  0.95  ]])

In [11]: P * s
Out[11]:
array([[ 0.9975   ,  0.0128125,  0.0125   ,  0.0121875,  0.011875 ],
       [ 0.013125 ,  0.97375  ,  0.0125   ,  0.0121875,  0.011875 ],
       [ 0.013125 ,  0.0128125,  0.95     ,  0.0121875,  0.011875 ],
       [ 0.013125 ,  0.0128125,  0.0125   ,  0.92625  ,  0.011875 ],
       [ 0.013125 ,  0.0128125,  0.0125   ,  0.0121875,  0.9025   ]])

In [12]: P * np.reshape(s, (5, 1))
Out[12]:
array([[ 0.9975   ,  0.013125 ,  0.013125 ,  0.013125 ,  0.013125 ],
       [ 0.0128125,  0.97375  ,  0.0128125,  0.0128125,  0.0128125],
       [ 0.0125   ,  0.0125   ,  0.95     ,  0.0125   ,  0.0125   ],
       [ 0.0121875,  0.0121875,  0.0121875,  0.92625  ,  0.0121875],
       [ 0.011875 ,  0.011875 ,  0.011875 ,  0.011875 ,  0.9025   ]])
```

Notice that the 3rd element of `s` is `1.0`. This means that if we are trying to calculate `P[i, j] * s[j]` we should have that the 3rd column of the result equal to the third column of `P`.  We see that this is true when `s` is left as a 1-dimensional array, but when it moves to 2-d we instead see that the entire 3rd **row** is left unchanged. 
