### PR TITLE
BUG: fixed bug in asset pricing solutions

### DIFF
--- a/solutions/asset_solutions.ipynb
+++ b/solutions/asset_solutions.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:be473fdc232f4a9ed6d2906c14ff3e9d9aaac53dfaef16f2e1543b6478a4379a"
+  "signature": "sha256:31be1cf5c625614688a9b398b7c8e2dc1621c59b69b9e74e66330c67bf30727a"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -82,7 +82,7 @@
       "print \"Consol Bond Prices: \", v_consol\n",
       "\n",
       "P_tilde = P * s**(1-gamma)\n",
-      "temp = beta * P_tilde.dot(v) - beta * P_tilde.dot(np.ones(n))\n",
+      "temp = beta * P_tilde.dot(v) + beta * P_tilde.dot(np.ones(n))\n",
       "print \"Should be 0: \",  v - temp \n",
       "\n",
       "p_s = 150.0\n",
@@ -95,9 +95,10 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "Lucas Tree Prices:  [ 12.28465197  14.42111319  17.45713702  22.11237355  30.15323666]\n",
-        "Consol Bond Prices:  [  75.51427238   98.64225987  140.69501276  240.82930111  786.23683599]\n",
-        "Should be 0:  [ 1.72509033  1.79371484  1.86577057  1.94152147  2.02125926]\n"
+        "Lucas Tree Prices:  [ 12.72221763  14.72515002  17.57142236  21.93570661  29.47401578]\n",
+        "Consol Bond Prices:  [  87.56860139  109.25108965  148.67554548  242.55144082  753.87100476]\n",
+        "Should be 0:  [  0.00000000e+00  -1.77635684e-15   0.00000000e+00   0.00000000e+00\n",
+        "   0.00000000e+00]\n"
        ]
       }
      ],


### PR DESCRIPTION
we were trying to verify that the computed v was a fixed point of
the value function, but we were using the wrong equation.

All I needed to do was swap a `-` for a `+`.
