### PR TITLE
DOCS: Added a pip-requirements so that readthedocs can build the documentation

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,0 +1,14 @@
+# These are the required packages for the quant-econ package to build
+
+ipython
+
+numpy
+
+numpydoc
+
+scipy
+
+matplotlib
+
+pandas
+


### PR DESCRIPTION
Worked on setting up the readthedocs.  Needs this file and then should be able to build from the master branch (right now I have it reading from this branch, but when pull request is accepted I can change that).
