### PR TITLE
ENH: added distributions.py file and moved Beta-binomial to it

### DIFF
--- a/examples/beta-binomial.py
+++ b/examples/beta-binomial.py
@@ -3,23 +3,16 @@ Filename: beta-binomial.py
 Authors: John Stachurski, Thomas J. Sargent
 
 """
-from scipy.special import binom, beta
 import matplotlib.pyplot as plt
-import numpy as np
-
-def gen_probs(n, a, b):
-    probs = np.zeros(n+1)
-    for k in range(n+1):
-        probs[k] = binom(n, k) * beta(k + a, n - k + b) / beta(a, b)
-    return probs
+from quantecon.distributions import BetaBinomial
 
 n = 50
 a_vals = [0.5, 1, 100]
 b_vals = [0.5, 1, 100]
 fig, ax = plt.subplots()
 for a, b in zip(a_vals, b_vals):
-    ab_label = r'$a = %.1f$, $b = %.1f$' % (a, b)
-    ax.plot(list(range(0, n+1)), gen_probs(n, a, b), '-o', label=ab_label)
+    ab_label = r"$a = %.1f$, $b = %.1f$" % (a, b)
+    ax.plot(list(range(0, n+1)), BetaBinomial(n, a, b).pdf(), "-o",
+            label=ab_label)
 ax.legend()
 plt.show()
-

--- a/quantecon/career.py
+++ b/quantecon/career.py
@@ -3,8 +3,7 @@ Filename: career.py
 
 Authors: Thomas Sargent, John Stachurski
 
-A collection of functions to solve the career / job choice model due to
-Derek Neal.
+A class to solve the career / job choice model due to Derek Neal.
 
 References
 ----------
@@ -17,43 +16,10 @@ http://quant-econ.net/career.html
 """
 
 import numpy as np
-from scipy.special import binom, beta
+from quantecon.distributions import BetaBinomial
 
 
-def gen_probs(n, a, b):
-    r"""
-    Generate the vector of probabilities for the Beta-binomial
-    (n, a, b) distribution.
-
-    The Beta-binomial distribution takes the form
-
-    .. math::
-        p(k \,|\, n, a, b) =
-        {n \choose k} \frac{B(k + a, n - k + b)}{B(a, b)},
-        \qquad k = 0, \ldots, n
-
-    Parameters
-    ----------
-    n : scalar(int)
-        First parameter to the Beta-binomial distribution
-    a : scalar(float)
-        Second parameter to the Beta-binomial distribution
-    b : scalar(float)
-        Third parameter to the Beta-binomial distribution
-
-    Returns
-    -------
-    probs: array_like(float)
-        Vector of probabilities over k
-
-    """
-    probs = np.zeros(n+1)
-    for k in range(n+1):
-        probs[k] = binom(n, k) * beta(k + a, n - k + b) / beta(a, b)
-    return probs
-
-
-class CareerWorkerProblem:
+class CareerWorkerProblem(object):
     """
     An instance of the class is an object with data on a particular
     problem of this type, including probabilites, discount factor and
@@ -104,8 +70,8 @@ class CareerWorkerProblem:
         self.beta, self.N, self.B = beta, N, B
         self.theta = np.linspace(0, B, N)     # set of theta values
         self.epsilon = np.linspace(0, B, N)   # set of epsilon values
-        self.F_probs = gen_probs(N-1, F_a, F_b)
-        self.G_probs = gen_probs(N-1, G_a, G_b)
+        self.F_probs = BetaBinomial(N-1, F_a, F_b).pdf()
+        self.G_probs = BetaBinomial(N-1, G_a, G_b).pdf()
         self.F_mean = np.sum(self.theta * self.F_probs)
         self.G_mean = np.sum(self.epsilon * self.G_probs)
 
@@ -129,10 +95,10 @@ class CareerWorkerProblem:
         for i in range(self.N):
             for j in range(self.N):
                 v1 = self.theta[i] + self.epsilon[j] + self.beta * v[i, j]
-                v2 = self.theta[i] + self.G_mean + self.beta * \
-                        np.dot(v[i, :], self.G_probs)
-                v3 = self.G_mean + self.F_mean + self.beta * \
-                        np.dot(self.F_probs, np.dot(v, self.G_probs))
+                v2 = (self.theta[i] + self.G_mean + self.beta *
+                      np.dot(v[i, :], self.G_probs))
+                v3 = (self.G_mean + self.F_mean + self.beta *
+                      np.dot(self.F_probs, np.dot(v, self.G_probs)))
                 new_v[i, j] = max(v1, v2, v3)
         return new_v
 
@@ -161,10 +127,10 @@ class CareerWorkerProblem:
         for i in range(self.N):
             for j in range(self.N):
                 v1 = self.theta[i] + self.epsilon[j] + self.beta * v[i, j]
-                v2 = self.theta[i] + self.G_mean + self.beta * \
-                        np.dot(v[i, :], self.G_probs)
-                v3 = self.G_mean + self.F_mean + self.beta * \
-                        np.dot(self.F_probs, np.dot(v, self.G_probs))
+                v2 = (self.theta[i] + self.G_mean + self.beta *
+                      np.dot(v[i, :], self.G_probs))
+                v3 = (self.G_mean + self.F_mean + self.beta *
+                      np.dot(self.F_probs, np.dot(v, self.G_probs)))
                 if v1 > max(v2, v3):
                     action = 1
                 elif v2 > max(v1, v3):

--- a/quantecon/distributions.py
+++ b/quantecon/distributions.py
@@ -1,0 +1,133 @@
+"""
+Filename: distributions.py
+
+Probability distributions useful in economics.
+
+References
+----------
+
+http://en.wikipedia.org/wiki/Beta-binomial_distribution
+
+"""
+from math import sqrt
+import numpy as np
+from scipy.special import binom, beta
+
+
+class BetaBinomial(object):
+    """
+    The Beta-Binomial distribution
+
+    Parameters
+    ----------
+    n : scalar(int)
+        First parameter to the Beta-binomial distribution
+    a : scalar(float)
+        Second parameter to the Beta-binomial distribution
+    b : scalar(float)
+        Third parameter to the Beta-binomial distribution
+
+    Attributes
+    ----------
+    n : scalar(int)
+        First parameter to the Beta-binomial distribution
+    a : scalar(float)
+        Second parameter to the Beta-binomial distribution
+    b : scalar(float)
+        Third parameter to the Beta-binomial distribution
+
+    """
+
+    def __init__(self, n, a, b):
+        self.n, self.a, self.b = n, a, b
+
+    @property
+    def mean(self):
+        "mean"
+        n, a, b = self.n, self.a, self.b
+        return n * a / (a + b)
+
+    @property
+    def std(self):
+        "standard deviation"
+        return sqrt(self.var)
+
+    @property
+    def var(self):
+        "Variance"
+        n, a, b = self.n, self.a, self.b
+        top = n*a*b * (a + b + n)
+        btm = (a+b)**2.0 * (a+b+1.0)
+        return top / btm
+
+    @property
+    def skew(self):
+        "skewness"
+        n, a, b = self.n, self.a, self.b
+        t1 = (a+b+2*n) * (b - a) / (a+b+2)
+        t2 = sqrt((1+a+b) / (n*a*b * (n+a+b)))
+        return t1 * t2
+
+    def pdf(self):
+        r"""
+        Generate the vector of probabilities for the Beta-binomial
+        (n, a, b) distribution.
+
+        The Beta-binomial distribution takes the form
+
+        .. math::
+            p(k \,|\, n, a, b) =
+            {n \choose k} \frac{B(k + a, n - k + b)}{B(a, b)},
+            \qquad k = 0, \ldots, n,
+
+        where :math:`B` is the beta function.
+
+        Parameters
+        ----------
+        n : scalar(int)
+            First parameter to the Beta-binomial distribution
+        a : scalar(float)
+            Second parameter to the Beta-binomial distribution
+        b : scalar(float)
+            Third parameter to the Beta-binomial distribution
+
+        Returns
+        -------
+        probs: array_like(float)
+            Vector of probabilities over k
+
+        """
+        n, a, b = self.n, self.a, self.b
+        k = np.arange(n + 1)
+        probs = binom(n, k) * beta(k + a, n - k + b) / beta(a, b)
+        return probs
+
+    # def cdf(self):
+    #     r"""
+    #     Generate the vector of cumulative probabilities for the
+    #     Beta-binomial(n, a, b) distribution.
+
+    #     The cdf of the Beta-binomial distribution takes the form
+
+    #     .. math::
+    #         P(k \,|\, n, a, b) = 1 -
+    #         \frac{B(b+n-k-1, a+k+1) {}_3F_2(a,b;k)}{B(a,b) B(n-k, k+2)},
+    #         \qquad k = 0, \ldots, n
+
+    #     where :math:`B` is the beta function.
+
+    #     Parameters
+    #     ----------
+    #     n : scalar(int)
+    #         First parameter to the Beta-binomial distribution
+    #     a : scalar(float)
+    #         Second parameter to the Beta-binomial distribution
+    #     b : scalar(float)
+    #         Third parameter to the Beta-binomial distribution
+
+    #     Returns
+    #     -------
+    #     probs: array_like(float)
+    #         Vector of probabilities over k
+
+    #     """


### PR DESCRIPTION
Right now we have the function `gen_probs` in career.py. This function computes the pdf (pmf) of the BetaBinomial distribution. I didn't feel like it belonged in the same file as the `CareerWorkerProblem`, as it isn't specific to that model.

This PR moves this function out of `career.py` into a new file `distributions.py`. In this file we can collect other probability distributions that aren't included in `scipy.stats` as we progress. 

I am not sure if this is a pareto improving change, so if anyone doesn't think it is -- comment here and we can find the optimal solution. 

---

**Warning**: This PR might create a merge conflict with #38 when it is merged as both PRs change `career.py`. 
