### PR TITLE
Adding Version Attribute to QuantEcon class

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -19,3 +19,6 @@ from .rank_nullspace import rank_est, nullspace
 from .robustlq import RBLQ
 from .tauchen import approx_markov
 from . import quad as quad
+
+#Add Version Attribute
+from .version import version as __version__

--- a/quantecon/version.py
+++ b/quantecon/version.py
@@ -1,0 +1,4 @@
+"""
+This is a VERSION file and should NOT be manually altered
+"""
+version = '0.1.5'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,31 @@
 from distutils.core import setup
+import os
+
+#-Write a versions.py file for class attribute-#
+
+VERSION = '0.1.5'
+
+def write_version_py(filename=None):
+    doc = "\"\"\"\nThis is a VERSION file and should NOT be manually altered\n\"\"\""
+    doc += "\nversion = '%s'" % VERSION
+    
+    if not filename:
+        filename = os.path.join(
+            os.path.dirname(__file__), 'quantecon', 'version.py')
+
+    fl = open(filename, 'w')
+    try:
+        fl.write(doc)
+    finally:
+        fl.close()
+
+write_version_py()
+
+#-Setup-#
 
 setup(name='quantecon',
       packages=['quantecon', 'quantecon.models', "quantecon.tests"],
-      version='0.1.5',
+      version=VERSION,
       description='Core package of the QuantEcon library',
       author='Thomas J. Sargent and John Stachurski (Project coordinators)',
       author_email='john.stachurski@gmail.com',


### PR DESCRIPTION
This PR adds a version attribute to the QuantEcon class that is derived from `setup.py`. When you run `python setup.py install` this generates a `version.py` file and places it in the `quantecon` package for use by `__init__.py` which attaches the `__version__` attribute to the package. 

Version can be checked using: 

``` python
import quantecon as qe
qe.__version__
```
## Future Work
1. Pandas generates the `version.py` file on build and therefore places a `version.py` file in the `site-packages` location without adding it to the repository. For now I have added a docstring to the file with a reminder not to edit it - as it will get overwritten with every install command. 
