### PR TITLE
BUG: cartesian grids also work with integers

### DIFF
--- a/quantecon/cartesian.py
+++ b/quantecon/cartesian.py
@@ -25,9 +25,11 @@ def cartesian(nodes, order='C'):
     nodes = [numpy.array(e) for e in nodes]
     shapes = [e.shape[0] for e in nodes]
 
+    dtype = nodes[0].dtype
+
     n = len(nodes)
     l = numpy.prod(shapes)
-    out = numpy.zeros((l, n))
+    out = numpy.zeros((l, n), dtype=dtype)
 
 
     if order == 'C':

--- a/quantecon/tests/test_cartesian.py
+++ b/quantecon/tests/test_cartesian.py
@@ -22,6 +22,18 @@ def test_cartesian_C_order():
 
     assert(correct)
 
+def test_cartesian_C_order_int_float():
+
+    from numpy import arange, linspace
+
+    x_int = arange(10)
+    x_float = linspace(0,9,10)
+    prod_int = cartesian([x_int]*3)
+    prod_float = cartesian([x_float]*3)
+    assert(prod_int.dtype==x_int.dtype)
+    assert(prod_float.dtype==x_float.dtype)
+    assert( abs(prod_int-prod_float).max()==0)
+
 def test_cartesian_F_order():
 
     from numpy import linspace


### PR DESCRIPTION
Ridiculously pull request to adress issue #98 .
It doesn't address the accessibility problem though, as I don't know what would work best to replace `cartesian` as a module name.
