### PR TITLE
BUG: Fix bug for input with int elements

### DIFF
--- a/quantecon/gth_solve.py
+++ b/quantecon/gth_solve.py
@@ -60,7 +60,7 @@ def gth_solve(A, overwrite=False):
        Simulation, Princeton University Press, 2009.
 
     """
-    A1 = np.array(A, copy=not overwrite)
+    A1 = np.array(A, dtype=float, copy=not overwrite)
 
     if len(A1.shape) != 2 or A1.shape[0] != A1.shape[1]:
         raise ValueError('matrix must be square')

--- a/quantecon/tests/test_gth_solve.py
+++ b/quantecon/tests/test_gth_solve.py
@@ -67,7 +67,7 @@ class Matrices:
 
         matrix_dict = {
             'A': np.array([[0.4, 0.6], [0.2, 0.8]]),
-            'stationary_dist': np.array([[0.25, 0.75]]),
+            'stationary_dist': np.array([0.25, 0.75]),
         }
         self.stoch_matrix_dicts.append(matrix_dict)
 
@@ -75,7 +75,7 @@ class Matrices:
             # Reducible matrix
             'A': np.array([[1, 0], [0, 1]]),
             # Stationary dist whose support contains index 0
-            'stationary_dist': np.array([[1, 0]]),
+            'stationary_dist': np.array([1, 0]),
         }
         self.stoch_matrix_dicts.append(matrix_dict)
 
@@ -90,8 +90,8 @@ class Matrices:
         self.kmr_matrix_dicts.append(matrix_dict)
 
         matrix_dict = {
-            'A': np.array([[-1, 1], [4, -4]]),
-            'stationary_dist': np.array([[0.8, 0.2]]),
+            'A': np.array([[-3, 3], [4, -4]]),
+            'stationary_dist': np.array([4/7, 3/7]),
         }
         self.gen_matrix_dicts.append(matrix_dict)
 


### PR DESCRIPTION
I found the [same bug](https://github.com/QuantEcon/QuantEcon.jl/pull/23#issuecomment-64198872) as in the Julia version. For an input matrix with integer elements, `gth_solve` returns a wrong answer:

``` python
>>> P = [[-3, 3], [4, -4]]  # Transition rate matrix
>>> gth_solve(P)
array([ 0.5,  0.5])
```

The correct answer is [4/7, 3/7].
(My choice of the instance was not clever so that the test failed to detect this bug...)

The current code now converts the input to float.
