### PR TITLE
Updating Developer and Coordinator links to website not github readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ at a terminal prompt
 
 ## Additional Links
 
-1. [Project Coordinators](https://github.com/QuantEcon/QuantEcon.site/blob/master/README.md)
-2. [Lead Developers](https://github.com/QuantEcon/QuantEcon.site/blob/master/README.md)
+1. [Project Coordinators](http://quantecon.org/about/#people)
+2. [Lead Developers](http://quantecon.org/about/#people)
 3. [QuantEcon Course Website](http://quant-econ.net)
 
 ### License


### PR DESCRIPTION
Changed to website information as a single source for Developers and Coordinator links. 
I will push the same change to Julia PR
