### PR TITLE
FIX: Discrete Lyapunov with complex input

### DIFF
--- a/quantecon/matrix_eqn.py
+++ b/quantecon/matrix_eqn.py
@@ -75,7 +75,7 @@ def solve_discrete_lyapunov(A, B, max_it=50, method="doubling"):
         while diff > 1e-15:
 
             alpha1 = alpha0.dot(alpha0)
-            gamma1 = gamma0 + np.dot(alpha0.dot(gamma0), alpha0.T)
+            gamma1 = gamma0 + np.dot(alpha0.dot(gamma0), alpha0.conjugate().T)
 
             diff = np.max(np.abs(gamma1 - gamma0))
             alpha0 = alpha1

--- a/quantecon/tests/test_matrix_eqn.py
+++ b/quantecon/tests/test_matrix_eqn.py
@@ -31,3 +31,14 @@ def test_solve_discrete_lyapunov_B():
 
     assert_allclose(B, X)
 
+def test_solve_discrete_lyapunov_complex():
+    'Complex test, A is companion matrix'
+    A = np.array([[0.5 + 0.3j, 0.1 + 0.1j],
+                  [         1,          0]])
+    B = np.eye(2)
+
+    X = qme.solve_discrete_lyapunov(A, B)
+
+    assert_allclose(np.dot(np.dot(A, X), A.conj().transpose()) - X, -B,
+                    atol=1e-15)
+


### PR DESCRIPTION
Minor issue with the discrete Lyapunov solver via doubling: a missing complex conjugation operation causes incorrect results if the input is complex. The unit test shows the failure in the current setup and passes with the fix.