### PR TITLE
Add symbolics base class

### DIFF
--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -62,7 +62,7 @@ class SymbolicBase(object):
 
     @property
     def _variable_subs(self):
-        """Variable substitutions."""
+        """Generic variable substitutions."""
         return dict(zip(self.dependent_vars, [X[i] for i in range(self.N)]))
 
     @property
@@ -184,7 +184,7 @@ class SymbolicBase(object):
     def _validate_rhs(self):
         raise NotImplementedError
 
-    def evaluate_jacobian(self, t, X, *args):
+    def evaluate_jacobian(self, t, X):
         """
         Return the Jacobian matrix of partial derivatives evaluated at specific
         values of the independent variable, `t`, and dependent variables, `X`.
@@ -195,8 +195,6 @@ class SymbolicBase(object):
             Independent variable.
         X : numpy.ndarray (shape=(N,))
             Array of values for the `N` dependent variables.
-        args : tuple
-            Additional parameter arguments necessary to evaluate the Jacobian.
 
         Returns
         -------
@@ -204,10 +202,10 @@ class SymbolicBase(object):
             Evaluated Jacobian matrix.
 
         """
-        jac = self._jacobian(t, X, *args)
+        jac = self._jacobian(t, X, *self.params.values())
         return jac
 
-    def evaluate_rhs(self, t, X, *args):
+    def evaluate_rhs(self, t, X):
         """
         Return the right-hand side of a system of differential/difference
         equations evaluated at specific values of the independent variable,
@@ -219,8 +217,6 @@ class SymbolicBase(object):
             Independent variable.
         X : numpy.ndarray (shape=(N,))
             Array of values for the `N` dependent variables.
-        args : tuple
-            Additional parameter arguments necessary to evaluate the Jacobian.
 
         Returns
         -------
@@ -228,5 +224,5 @@ class SymbolicBase(object):
             Evaluated Jacobian matrix.
 
         """
-        rhs = self._rhs(t, X, *args)
+        rhs = self._rhs(t, X, *self.params.values())
         return rhs

--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -187,8 +187,13 @@ class SymbolicBase(object):
         else:
             return value
 
-    def _validate_rhs(self):
-        raise NotImplementedError
+    def _validate_rhs(self, rhs):
+        """Validate the rhs attribute."""
+        if not (rhs.shape[0] == len(self.dependent_vars)):
+            mesg = "Number of equations must equal number of dependent variables."
+            raise ValueError(mesg)
+        else:
+            return rhs
 
     def compute_eigenvalues(self, t, X):
         """

--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -9,6 +9,7 @@ from __future__ import division
 import collections
 
 import numpy as np
+from scipy import linalg
 import sympy as sym
 
 # declare generic symbolic variables
@@ -188,6 +189,28 @@ class SymbolicBase(object):
 
     def _validate_rhs(self):
         raise NotImplementedError
+
+    def compute_eigenvalues(self, t, X):
+        """
+        Compute the eigenvalues of the Jacobian matrix of partial derivatives
+        evaluated at specific values of the independent variable, `t`, and
+        dependent variables, `X`.
+
+        Parameters
+        ----------
+        t : float
+            Independent variable.
+        X : numpy.ndarray (shape=(N,))
+            Array of values for the `N` dependent variables.
+
+        Returns
+        -------
+        eigvals : numpy.ndarray (shape=(N,))
+            Array of eigenvalues of the Jacobian matrix.
+
+        """
+        eigvals = linalg.eigvals(self.evaluate_jacobian(t, X))
+        return eigvals
 
     def evaluate_jacobian(self, t, X):
         """

--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -27,6 +27,8 @@ class SymbolicBase(object):
 
     __numeric_rhs = None
 
+    __symbolic_jacobian = None
+
     _modules = [{'ImmutableMatrix': np.array}, 'numpy']
 
     @property
@@ -108,7 +110,9 @@ class SymbolicBase(object):
         :type: sympy.Matrix
 
         """
-        return self.rhs.jacobian(self.dependent_vars)
+        if self.__symbolic_jacobian is None:
+            self.__symbolic_jacobian = self.rhs.jacobian(self.dependent_vars)
+        return self.__symbolic_jacobian
 
     @property
     def N(self):
@@ -162,6 +166,7 @@ class SymbolicBase(object):
         """Clear cached values."""
         self.__numeric_jacobian = None
         self.__numeric_rhs = None
+        self.__symbolic_jacobian = None
 
     def _lambdify_factory(self, expression):
         """Lambdify a symbolic expression."""

--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -12,9 +12,6 @@ import numpy as np
 from scipy import linalg
 import sympy as sym
 
-# declare generic symbolic variables
-t, X = sym.symbols('t'), sym.DeferredVector('X')
-
 
 class SymbolicBase(object):
     """
@@ -36,16 +33,14 @@ class SymbolicBase(object):
     def _numeric_jacobian(self):
         """Vectorized function for evaluating Jacobian matrix."""
         if self.__numeric_jacobian is None:
-            expr = self.jacobian.subs(self._variable_subs)
-            self.__numeric_jacobian = self._lambdify_factory(expr)
+            self.__numeric_jacobian = self._lambdify_factory(self.jacobian)
         return self.__numeric_jacobian
 
     @property
     def _numeric_rhs(self):
         """Vectorized function for evaluating right-hand side of system."""
         if self.__numeric_rhs is None:
-            expr = self.rhs.subs(self._variable_subs)
-            self.__numeric_rhs = self._lambdify_factory(expr)
+            self.__numeric_rhs = self._lambdify_factory(self.rhs)
         return self.__numeric_rhs
 
     @property
@@ -61,12 +56,7 @@ class SymbolicBase(object):
     @property
     def _symbolic_vars(self):
         """List of symbolic model variables."""
-        return [t, X]
-
-    @property
-    def _variable_subs(self):
-        """Generic variable substitutions."""
-        return dict(zip(self.dependent_vars, [X[i] for i in range(self.N)]))
+        return self.independent_var + self.dependent_vars
 
     @property
     def dependent_vars(self):

--- a/quantecon/models/solow/bases.py
+++ b/quantecon/models/solow/bases.py
@@ -1,0 +1,232 @@
+"""
+Base class for representing a system of differential/difference equations
+that needs to convert SymPy expressions into vectorized, NumPy-aware functions.
+
+@author : davidrpugh
+
+"""
+from __future__ import division
+import collections
+
+import numpy as np
+import sympy as sym
+
+# declare generic symbolic variables
+t, X = sym.symbols('t'), sym.DeferredVector('X')
+
+
+class SymbolicBase(object):
+    """
+    Base class for representing a system of differential/difference equations
+    that needs to convert SymPy expressions into vectorized, NumPy-aware
+    functions.
+
+    """
+
+    __numeric_jacobian = None
+
+    __numeric_rhs = None
+
+    _modules = [{'ImmutableMatrix': np.array}, 'numpy']
+
+    @property
+    def _numeric_jacobian(self):
+        """Vectorized function for evaluating Jacobian matrix."""
+        if self.__numeric_jacobian is None:
+            expr = self.jacobian.subs(self._variable_subs)
+            self.__numeric_jacobian = self._lambdify_factory(expr)
+        return self.__numeric_jacobian
+
+    @property
+    def _numeric_rhs(self):
+        """Vectorized function for evaluating right-hand side of system."""
+        if self.__numeric_rhs is None:
+            expr = self.rhs.subs(self._variable_subs)
+            self.__numeric_rhs = self._lambdify_factory(expr)
+        return self.__numeric_rhs
+
+    @property
+    def _symbolic_args(self):
+        """List of symbolic arguments used to lambdify expressions."""
+        return self._symbolic_vars + self._symbolic_params
+
+    @property
+    def _symbolic_params(self):
+        """List of symbolic model parameters."""
+        return sym.var(list(self.params.keys()))
+
+    @property
+    def _symbolic_vars(self):
+        """List of symbolic model variables."""
+        return [t, X]
+
+    @property
+    def _variable_subs(self):
+        """Variable substitutions."""
+        return dict(zip(self.dependent_vars, [X[i] for i in range(self.N)]))
+
+    @property
+    def dependent_vars(self):
+        """
+        Model dependent variables.
+
+        :getter: Return the model dependent variables.
+        :setter: Set new model dependent variables.
+        :type: list
+
+        """
+        return self._dependent_variables
+
+    @dependent_vars.setter
+    def dependent_vars(self, symbols):
+        """Set new list of dependent variables."""
+        self._dependent_variables = symbols
+
+    @property
+    def independent_var(self):
+        """
+        Symbolic variable representing the independent variable.
+
+        :getter: Return the symbol representing the independent variable.
+        :setter: Set a new symbol to represent the independent variable.
+        :type: sympy.Symbol
+
+        """
+        return self._independent_var
+
+    @independent_var.setter
+    def independent_var(self, symbol):
+        """Set a new symbol to represent the independent variable."""
+        self._independent_var = symbol
+
+    @property
+    def jacobian(self):
+        """
+        Symbolic Jacobian matrix of partial derivatives.
+
+        :getter: Return the Jacobian matrix.
+        :type: sympy.Matrix
+
+        """
+        return self.rhs.jacobian(self.dependent_vars)
+
+    @property
+    def N(self):
+        """
+        Dimension of the symbolic system of equations.
+
+        :getter: Return the current dimension.
+        :type: int
+
+        """
+        return self.rhs.shape[0]
+
+    @property
+    def params(self):
+        """
+        Dictionary of model parameters.
+
+        :getter: Return the current parameter dictionary.
+        :setter: Set a new parameter dictionary.
+        :type: dict
+
+        """
+        return self._params
+
+    @params.setter
+    def params(self, value):
+        """Set a new parameter dictionary."""
+        valid_params = self._validate_params(value)
+        self._params = self._order_params(valid_params)
+
+    @property
+    def rhs(self):
+        """
+        Symbolic representation of the right-hand side of a system of
+        differential/difference equations.
+
+        :getter: Return the right-hand side of the system of equations.
+        :setter: Set a new right-hand side of the system of equations.
+        :type: sympy.Matrix
+
+        """
+        return self._rhs
+
+    @rhs.setter
+    def rhs(self, system):
+        """Set a new right-hand side of the system of equations."""
+        self._rhs = self._validate_rhs(system)
+        self._clear_cache()
+
+    def _clear_cache(self):
+        """Clear cached values."""
+        self.__numeric_jacobian = None
+        self.__numeric_rhs = None
+
+    def _lambdify_factory(self, expression):
+        """Lambdify a symbolic expression."""
+        return sym.lambdify(self._symbolic_args, expression, self._modules)
+
+    @staticmethod
+    def _order_params(params):
+        """Cast a dictionary to an order dictionary."""
+        return collections.OrderedDict(sorted(params.items()))
+
+    @staticmethod
+    def _validate_params(value):
+        """Validate the dictionary of parameters."""
+        if not isinstance(value, dict):
+            mesg = "Attribute 'params' must have type dict, not {}"
+            raise AttributeError(mesg.format(value.__class__))
+        else:
+            return value
+
+    def _validate_rhs(self):
+        raise NotImplementedError
+
+    def evaluate_jacobian(self, t, X, *args):
+        """
+        Return the Jacobian matrix of partial derivatives evaluated at specific
+        values of the independent variable, `t`, and dependent variables, `X`.
+
+        Parameters
+        ----------
+        t : float
+            Independent variable.
+        X : numpy.ndarray (shape=(N,))
+            Array of values for the `N` dependent variables.
+        args : tuple
+            Additional parameter arguments necessary to evaluate the Jacobian.
+
+        Returns
+        -------
+        jac : numpy.ndarray (shape=(N,N))
+            Evaluated Jacobian matrix.
+
+        """
+        jac = self._jacobian(t, X, *args)
+        return jac
+
+    def evaluate_rhs(self, t, X, *args):
+        """
+        Return the right-hand side of a system of differential/difference
+        equations evaluated at specific values of the independent variable,
+        `t`, and dependent variables, `X`.
+
+        Parameters
+        ----------
+        t : float
+            Independent variable.
+        X : numpy.ndarray (shape=(N,))
+            Array of values for the `N` dependent variables.
+        args : tuple
+            Additional parameter arguments necessary to evaluate the Jacobian.
+
+        Returns
+        -------
+        rhs : numpy.ndarray (shape=(N,N))
+            Evaluated Jacobian matrix.
+
+        """
+        rhs = self._rhs(t, X, *args)
+        return rhs


### PR DESCRIPTION
@albop @spencerlyon2 @jstac @cc7768 

I have been thinking about how to specify a generic base class for continuous-time models.  Here is my first draft of said base class (only spent about and hour or so on this so I am sure that there are many improvements that could be made).

The basic idea is that the user should specify the following primitives:

1. `rhs`: This would be a `sympy.Matrix` representing the right-hand side of a system of linear/non-linear differential/difference equations.
2. `independent_var`: This would be a `sympy.Symbol` representing the independent variable in the model (i.e., time in a dynamic setting).
3. `dependent_vars`: List of `sympy.Symbols` representing the dependent variables for the model (obviously number of equations should match the number of dependent variables).
4. `params`: dictionary of parameter values.

From these primitives, the base class would provide the functionality to build the Jacobian for the right-hand side and convert both the symbolic Jacobian and the symbolic right-hand side into vectorized, NumPy-aware functions.  

I could imagine two classes that might inherit directly from `SymbolicBase`:

```python
class DifferentialEquation(SymbolicBase):
    pass


class DifferenceEquation(SymbolicBase):
    pass
```

All instances of `DifferentialEquation` would then be passed to a `Solver`, which depending on the type of differential equation and boundary conditions, might be the solvers that currently exist in the `IVP` module (or perhaps some other solvers such as orthogonal collocation solvers, finite element solvers, etc.  Meanwhile, all instance of `DifferenceEquation` would be passed to a `Simulator` that would efficiently simulate the system of difference equations.

Thoughts and feedback would be much appreciated.


