### PR TITLE
Fixed import statements in __init__.py to include solow module.

### DIFF
--- a/quantecon/models/__init__.py
+++ b/quantecon/models/__init__.py
@@ -6,8 +6,10 @@ objects imported here will live in the `quantecon.models` namespace
 """
 
 __all__ = ["AssetPrices", "CareerWorkerProblem", "ConsumerProblem",
-           "JvWorker", "LucasTree", "SearchProblem", "GrowthModel"]
+           "JvWorker", "LucasTree", "SearchProblem", "GrowthModel",
+           "solow"]
 
+from . import solow
 from .asset_pricing import AssetPrices
 from .career import CareerWorkerProblem
 from .ifp import ConsumerProblem


### PR DESCRIPTION
@jstac @spencerlyon2 

I noticed when I upgraded to the new release of `quantecon` that
```
from quantecon.models import solow
```
command that had been working on my machine was no longer working.  Not sure exactly what the problem is. After checking the `__init__.py` file in the `models` module I noticed that `solow` was not in the module's name space.  This PR should fix that problem. Again, everything is working on my machine but it would be good to get independent verification.