### PR TITLE
Fixed imports for solow module...again!

### DIFF
--- a/quantecon/models/__init__.py
+++ b/quantecon/models/__init__.py
@@ -9,7 +9,7 @@ __all__ = ["AssetPrices", "CareerWorkerProblem", "ConsumerProblem",
            "JvWorker", "LucasTree", "SearchProblem", "GrowthModel",
            "solow"]
 
-from . import solow
+from . import solow as solow
 from .asset_pricing import AssetPrices
 from .career import CareerWorkerProblem
 from .ifp import ConsumerProblem


### PR DESCRIPTION
@jstac 

This PR fixes the import statement for the `solow` module. Note that I am able to import `quantecon` cleanly from my root directory (i.e., outside the repo)...
```python
Davids-MacBook-Pro:~ drpugh$ source activate quantecon-dev
discarding /Users/drpugh/anaconda/bin from PATH
prepending /Users/drpugh/anaconda/envs/quantecon-dev/bin to PATH
(quantecon-dev)Davids-MacBook-Pro:~ drpugh$ ipython
Python 2.7.9 |Continuum Analytics, Inc.| (default, Dec 15 2014, 10:37:34) 
Type "copyright", "credits" or "license" for more information.

IPython 2.1.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import quantecon as qe

In [2]: qe.models.solow.
qe.models.solow.CESModel          qe.models.solow.cobb_douglas
qe.models.solow.CobbDouglasModel  qe.models.solow.impulse_response
qe.models.solow.Model             qe.models.solow.model
qe.models.solow.ces               

In [2]: quit
```

