### PR TITLE
Adjust mock and environment requirements for proper compilation on RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ if on_rtd:
         def __getattr__(cls, name):
             return Mock()
 
-    MOCK_MODULES = ['pandas', 'statsmodels', 'sympy', "sympy.mpmath", 'numba']
+    MOCK_MODULES = ['pandas', 'statsmodels', 'numba'] 						 
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/rtd-pip-requirements.txt
+++ b/rtd-pip-requirements.txt
@@ -1,6 +1,6 @@
 # These are the required packages for the quant-econ package to build
 
-Sphinx
+sphinx
 
 ipython
 
@@ -11,3 +11,5 @@ numpydoc
 scipy
 
 matplotlib
+
+sympy


### PR DESCRIPTION
This PR makes some minor adjustments to allow the ``readthedocs`` to compile properly. The ``solow`` module's use of ``sympy`` created issues for the ``sympy`` mock. 

Add ``sympy`` to ``rtd`` requirements
Remove ``sympy`` from mock. 

http://quanteconpy.readthedocs.org/en/solow-rtd-fix/index.html

Notes
  1. ``qe_apidoc`` still needs to be updated to reflect the presence of the ``solow`` module. 