### PR TITLE
Testing mc_sample_path with np.random.seed

### DIFF
--- a/quantecon/tests/test_mc_tools.py
+++ b/quantecon/tests/test_mc_tools.py
@@ -229,6 +229,17 @@ def test_simulate_for_matrices_with_C_F_orders():
     assert_array_equal(computed_F, sample_path)
 
 
+def test_mc_sample_path_seed():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    init = 0
+    sample_size = 10
+
+    np.random.seed(42)
+    expected = [0, 1, 1, 1, 0, 0, 0, 1, 1, 1]
+    computed = mc_sample_path(P, init=init, sample_size=sample_size)
+    assert_array_equal(computed, expected)
+
+
 @raises(ValueError)
 def test_raises_value_error_non_2dim():
     """Test with non 2dim input"""


### PR DESCRIPTION
Following the discussion in #147:

```python
>>> import numpy as np
>>> prng = np.random.RandomState(42)
>>> u = prng.random_sample(size=10)
>>> u
array([ 0.37454012,  0.95071431,  0.73199394,  0.59865848,  0.15601864,
        0.15599452,  0.05808361,  0.86617615,  0.60111501,  0.70807258])
```

Let `P = [[0.4, 0.6], [0.2, 0.8]]`, `init = 0` (so `u[0]` is not used), and `sample_size = 10`. Given the values in `u[1:]`, `mc_sample_path` should return `[0, 1, 1, 1, 0, 0, 0, 1, 1, 1]`.

