### PR TITLE
MarkovChain.simulate API change; random_state option added

### DIFF
--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -91,19 +91,7 @@ from .gth_solve import gth_solve
 from ..graph_tools import DiGraph
 
 # -Check if Numba is Available- #
-<<<<<<< HEAD
-<<<<<<< HEAD
-from ..util import searchsorted, numba_installed, jit
-=======
-from .external import numba_installed, jit
-
-from .util import searchsorted, check_random_state
->>>>>>> `random_state` option, as well as tests, added
-=======
-from ..external import numba_installed, jit
-
-from ..util import searchsorted, check_random_state
->>>>>>> Import statements corrected
+from ..util import searchsorted, check_random_state, numba_installed, jit
 
 
 class MarkovChain(object):

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -140,11 +140,6 @@ class MarkovChain(object):
         List of numpy arrays containing the cyclic classes. Defined only
         when the Markov chain is irreducible.
 
-    Methods
-    -------
-    simulate : Simulates the markov chain for a given initial state or
-        distribution.
-
     """
 
     def __init__(self, P):
@@ -170,6 +165,7 @@ class MarkovChain(object):
         self.digraph = DiGraph(self.P)
 
         self._stationary_dists = None
+        self._cdfs = None
 
     def __repr__(self):
         msg = "Markov chain with transition matrix \nP = \n{0}"
@@ -256,9 +252,113 @@ class MarkovChain(object):
             self._compute_stationary()
         return self._stationary_dists
 
-    def simulate(self, init=0, sample_size=1000):
-        X = mc_sample_path(self.P, init, sample_size)
-        return X
+    @property
+    def cdfs(self):
+        if self._cdfs is None:
+            # See issue #137#issuecomment-96128186
+            cdfs = np.empty((self.n, self.n), order='C')
+            np.cumsum(self.P, axis=-1, out=cdfs)
+            self._cdfs = cdfs
+        return self._cdfs
+
+    def simulate(self, ts_length, init=None, num_reps=None):
+        """
+        Simulate time series of state transitions.
+
+        Parameters
+        ----------
+        ts_length : scalar(int)
+            Length of each simulation.
+
+        init : scalar(int) or array_like(int, ndim=1),
+               optional(default=None)
+            Initial state(s). If None, the initial state is randomly
+            drawn.
+
+        num_reps : scalar(int), optional(default=None)
+            Number of simulations. Relevant only when init is a scalar
+            or None.
+
+        Returns
+        -------
+        X : ndarray(int, ndim=1 or 2)
+            Array containing the sample path(s), of shape (ts_length,)
+            if init is a scalar (integer) or None and num_reps is None;
+            of shape (k, ts_length) otherwise, where k = len(init) if
+            init is an array_like, otherwise k = num_reps.
+
+        """
+        try:
+            num_reps = len(init)  # init is an array; make num_reps not None
+            init_states = np.asarray(init, dtype=int)
+        except:  # init is a scalar(int) or None
+            k = 1 if num_reps is None else num_reps
+            if init is None:
+                init_states = np.random.randint(self.n, size=k)
+            elif isinstance(init, int):
+                init_states = np.ones(k, dtype=int) * init
+            else:
+                raise ValueError(
+                    'init must be int, array_like of ints, or None'
+                )
+
+        X = _simulate_markov_chain(self.cdfs, ts_length, init_states,
+                                   random_state=np.random.RandomState())
+
+        if num_reps is None:
+            return X[0]
+        else:
+            return X
+
+
+def _simulate_markov_chain(P_cdfs, ts_length, init_states, random_state):
+    """
+    Main body of MarkovChain.simulate.
+
+    Generate len(init_states) sample paths of length ts_length.
+
+    Parameters
+    ----------
+    P_cdfs : ndarray(float, ndim=2)
+        Array containing as rows the CDFs of the state transition.
+
+    ts_length : scalar(int)
+        Length of each sample path.
+
+    init_states : array_like(int, ndim=1)
+        Array containing the initial states.
+
+    random_state : np.random.RandomState
+
+    Returns
+    -------
+    X : ndarray(int, ndim=2)
+        Array containing the sample paths, of shape (len(init_states),
+        ts_length)
+
+    Notes
+    -----
+    This routine is jit-complied if the module Numba is vailable.
+
+    """
+    num_reps = len(init_states)
+
+    # === set up array to store output === #
+    X = np.empty((num_reps, ts_length), dtype=int)
+    X[:, 0] = init_states
+
+    # Random values, uniformly sampled from [0, 1)
+    u = random_state.random_sample(size=(num_reps, ts_length-1))
+
+    # === generate the sample paths === #
+    for i in range(num_reps):
+        for t in range(ts_length-1):
+            X[i, t+1] = searchsorted(P_cdfs[X[i, t]], u[i, t])
+
+    return X
+
+if numba_installed:
+    _simulate_markov_chain = jit(_simulate_markov_chain)
 
 
 def mc_compute_stationary(P):
@@ -278,76 +378,33 @@ def mc_compute_stationary(P):
 
 def mc_sample_path(P, init=0, sample_size=1000):
     """
-    See Section: DocStrings below
+    Generates one sample path from the Markov chain represented by
+    (n x n) transition matrix P on state space S = {{0,...,n-1}}.
+
+    Parameters
+    ----------
+    P : array_like(float, ndim=2)
+        A Markov transition matrix.
+
+    init : array_like(float ndim=1) or scalar(int), optional(default=0)
+        If init is an array_like, then it is treated as the initial
+        distribution across states.  If init is a scalar, then it
+        treated as the deterministic initial state.
+
+    sample_size : scalar(int), optional(default=1000)
+        The length of the sample path.
+
+    Returns
+    -------
+    X : array_like(int, ndim=1)
+        The simulation of states.
+
     """
-    n = len(P)
-
-    # CDFs, one for each row of P
-    cdfs = np.empty((n, n), order='C')  # see issue #137#issuecomment-96128186
-    np.cumsum(P, axis=-1, out=cdfs)
-
-    # Random values, uniformly sampled from [0, 1)
-    u = np.random.random(size=sample_size)
-
-    # === set up array to store output === #
-    X = np.empty(sample_size, dtype=int)
     if isinstance(init, int):
-        X[0] = init
+        X_0 = init
     else:
         cdf0 = np.cumsum(init)
-        X[0] = searchsorted(cdf0, u[0])
+        u_0 = np.random.random(size=1)
+        X_0 = searchsorted(cdf0, u_0)
 
-    # === generate the sample path === #
-    for t in range(sample_size-1):
-        X[t+1] = searchsorted(cdfs[X[t]], u[t+1])
-
-    return X
-
-if numba_installed:
-    mc_sample_path = jit(mc_sample_path)
-
-
-# ------------ #
-# -DocStrings- #
-# ------------ #
-
-# -mc_sample_path() function and MarkovChain.simulate() method- #
-_sample_path_docstr = \
-"""
-Generates one sample path from the Markov chain represented by (n x n)
-transition matrix P on state space S = {{0,...,n-1}}.
-
-Parameters
-----------
-{p_arg}
-init : array_like(float ndim=1) or scalar(int), optional(default=0)
-    If init is an array_like, then it is treated as the initial
-    distribution across states.  If init is a scalar, then it treated as
-    the deterministic initial state.
-
-sample_size : scalar(int), optional(default=1000)
-    The length of the sample path.
-
-Returns
--------
-X : array_like(int, ndim=1)
-    The simulation of states.
-
-"""
-
-# -Functions- #
-
-# -mc_sample_path- #
-mc_sample_path.__doc__ = _sample_path_docstr.format(p_arg="""
-P : array_like(float, ndim=2)
-    A Markov transition matrix.
-""")
-
-# -Methods- #
-
-# -Markovchain.simulate()- #
-if sys.version_info[0] == 3:
-    MarkovChain.simulate.__doc__ = _sample_path_docstr.format(p_arg="")
-elif sys.version_info[0] == 2:
-    MarkovChain.simulate.__func__.__doc__ = \
-        _sample_path_docstr.format(p_arg="")
+    return MarkovChain(P).simulate(ts_length=sample_size, init=X_0)

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -162,7 +162,7 @@ class MarkovChain(object):
         self.n = self.P.shape[0]
 
         # To analyze the structure of P as a directed graph
-        self.digraph = DiGraph(self.P)
+        self._digraph = None
 
         self._stationary_dists = None
         self._cdfs = None
@@ -178,6 +178,12 @@ class MarkovChain(object):
 
     def __str__(self):
         return str(self.__repr__)
+
+    @property
+    def digraph(self):
+        if self._digraph is None:
+            self._digraph = DiGraph(self.P)
+        return self._digraph
 
     @property
     def is_irreducible(self):

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -118,13 +118,6 @@ class MarkovChain(object):
     P : array_like(float, ndim=2)
         The transition matrix.  Must be of shape n x n.
 
-    random_state : scalar(int) or np.random.RandomState,
-                   optional(default=None)
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
-
     Attributes
     ----------
     P : see Parameters
@@ -160,7 +153,7 @@ class MarkovChain(object):
 
     """
 
-    def __init__(self, P, random_state=None):
+    def __init__(self, P):
         self.P = np.asarray(P)
 
         # Check Properties
@@ -178,9 +171,6 @@ class MarkovChain(object):
 
         # The number of states
         self.n = self.P.shape[0]
-
-        # random state
-        self.random_state = random_state
 
         # To analyze the structure of P as a directed graph
         self._digraph = None
@@ -288,7 +278,7 @@ class MarkovChain(object):
             self._cdfs = cdfs
         return self._cdfs
 
-    def simulate(self, ts_length, init=None, num_reps=None):
+    def simulate(self, ts_length, init=None, num_reps=None, random_state=None):
         """
         Simulate time series of state transitions.
 
@@ -306,6 +296,13 @@ class MarkovChain(object):
             Number of simulations. Relevant only when init is a scalar
             or None.
 
+        random_state : scalar(int) or np.random.RandomState,
+                       optional(default=None)
+            Random seed (integer) or np.random.RandomState instance to set
+            the initial state of the random number generator for
+            reproducibility. If None, a randomly initialized RandomState is
+            used.
+
         Returns
         -------
         X : ndarray(int, ndim=1 or 2)
@@ -315,7 +312,7 @@ class MarkovChain(object):
             init is an array_like, otherwise k = num_reps.
 
         """
-        random_state = check_random_state(self.random_state)
+        random_state = check_random_state(random_state)
 
         try:
             k = len(init)  # init is an array
@@ -439,5 +436,6 @@ def mc_sample_path(P, init=0, sample_size=1000, random_state=None):
         u_0 = random_state.random_sample()
         X_0 = searchsorted(cdf0, u_0)
 
-    mc = MarkovChain(P, random_state=random_state)
-    return mc.simulate(ts_length=sample_size, init=X_0)
+    mc = MarkovChain(P)
+    return mc.simulate(ts_length=sample_size, init=X_0,
+                       random_state=random_state)

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -2,7 +2,7 @@ r"""
 Authors: Chase Coleman, Spencer Lyon, Daisuke Oyama, Tom Sargent,
          John Stachurski
 
-Filename: mc_tools.py
+Filename: core.py
 
 This file contains some useful objects for handling a finite-state
 discrete-time Markov chain.
@@ -87,11 +87,11 @@ classes*. For each :math:`S_m` and each :math:`i \in S_m`, we have
 from __future__ import division
 import numpy as np
 from fractions import gcd
-import sys
-from .graph_tools import DiGraph
 from .gth_solve import gth_solve
+from ..graph_tools import DiGraph
 
 # -Check if Numba is Available- #
+<<<<<<< HEAD
 <<<<<<< HEAD
 from ..util import searchsorted, numba_installed, jit
 =======
@@ -99,6 +99,11 @@ from .external import numba_installed, jit
 
 from .util import searchsorted, check_random_state
 >>>>>>> `random_state` option, as well as tests, added
+=======
+from ..external import numba_installed, jit
+
+from ..util import searchsorted, check_random_state
+>>>>>>> Import statements corrected
 
 
 class MarkovChain(object):

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -216,6 +216,23 @@ class Test_markovchain_stationary_distributions_KMRMarkovMatrix2():
                 assert_allclose(np.dot(curr_v, mc.P), curr_v, atol=self.TOL)
 
 
+def test_simulate_shape():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    mc = MarkovChain(P)
+
+    (ts_length, init, num_reps) = (10, None, None)
+    assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
+                       (ts_length,))
+
+    for (ts_length, init, num_reps) in [(10, [0, 1], None), (10, [0, 1], 3)]:
+        assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
+                           (len(init), ts_length))
+
+    for (ts_length, init, num_reps) in [(10, None, 3), (10, None, 1)]:
+        assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
+                           (num_reps, ts_length))
+
+
 def test_simulate_for_matrices_with_C_F_orders():
     """
     Test MarkovChasin.simulate for matrices with C- and F-orders

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -233,16 +233,19 @@ def test_simulate_shape():
                            (num_reps, ts_length))
 
 
-def test_simulate_lln():
+def test_simulate_ergodicity():
     P = [[0.4, 0.6], [0.2, 0.8]]
     stationary_dist = [0.25, 0.75]
+    init = 0
     mc = MarkovChain(P)
 
-    seed = 34
-    ts_length = 10**4
-    tol = 0.02
+    seed = 4433
+    ts_length = 100
+    num_reps = 300
+    tol = 0.1
 
-    frequency_1 = mc.simulate(ts_length, random_state=seed).mean()
+    x = mc.simulate(ts_length, init=init, num_reps=num_reps, random_state=seed)
+    frequency_1 = x[:, -1].mean()
     ok_(np.abs(frequency_1 - stationary_dist[1]) < tol)
 
 
@@ -288,6 +291,20 @@ def test_mc_sample_path():
     computed = mc_sample_path(P, init=distribution, sample_size=sample_size,
                               random_state=seed)
     assert_array_equal(computed, expected)
+
+
+def test_mc_sample_path_lln():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    stationary_dist = [0.25, 0.75]
+    init = 0
+
+    seed = 4433
+    sample_size = 10**4
+    tol = 0.02
+
+    frequency_1 = mc_sample_path(P, init=init, sample_size=sample_size,
+                                 random_state=seed).mean()
+    ok_(np.abs(frequency_1 - stationary_dist[1]) < tol)
 
 
 @raises(ValueError)

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -256,6 +256,27 @@ def test_simulate_for_matrices_with_C_F_orders():
     assert_array_equal(computed_F, sample_path)
 
 
+def test_mc_sample_path():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    init = 0
+    sample_size = 10
+
+    seed = 42
+
+    # init: integer
+    expected = [0, 0, 1, 1, 1, 0, 0, 0, 1, 1]
+    computed = mc_sample_path(P, init=init, sample_size=sample_size,
+                              random_state=seed)
+    assert_array_equal(computed, expected)
+
+    # init: distribution
+    distribution = (0.5, 0.5)
+    expected = [0, 1, 1, 1, 0, 0, 0, 1, 1, 1]
+    computed = mc_sample_path(P, init=distribution, sample_size=sample_size,
+                              random_state=seed)
+    assert_array_equal(computed, expected)
+
+
 @raises(ValueError)
 def test_raises_value_error_non_2dim():
     """Test with non 2dim input"""

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -226,15 +226,15 @@ def test_simulate_for_matrices_with_C_F_orders():
     P_C = np.array([[0.5, 0.5], [0, 1]], order='C')
     P_F = np.array([[0.5, 0.5], [0, 1]], order='F')
     init = 1
-    sample_size = 10
-    sample_path = np.ones(sample_size, dtype=int)
+    ts_length = 10
+    sample_path = np.ones(ts_length, dtype=int)
 
     computed_C_and_F = \
-        MarkovChain(np.array([[1.]])).simulate(init=0, sample_size=sample_size)
-    assert_array_equal(computed_C_and_F, np.zeros(sample_size, dtype=int))
+        MarkovChain(np.array([[1.]])).simulate(ts_length, init=0)
+    assert_array_equal(computed_C_and_F, np.zeros(ts_length, dtype=int))
 
-    computed_C = MarkovChain(P_C).simulate(init, sample_size)
-    computed_F = MarkovChain(P_F).simulate(init, sample_size)
+    computed_C = MarkovChain(P_C).simulate(ts_length, init)
+    computed_F = MarkovChain(P_F).simulate(ts_length, init=init)
     assert_array_equal(computed_C, sample_path)
     assert_array_equal(computed_F, sample_path)
 

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
-from nose.tools import eq_, raises
+from nose.tools import eq_, ok_, raises
 
 from quantecon.markov import (
     MarkovChain, mc_compute_stationary, mc_sample_path
@@ -231,6 +231,19 @@ def test_simulate_shape():
     for (ts_length, init, num_reps) in [(10, None, 3), (10, None, 1)]:
         assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
                            (num_reps, ts_length))
+
+
+def test_simulate_lln():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    stationary_dist = [0.25, 0.75]
+    mc = MarkovChain(P)
+
+    seed = 34
+    ts_length = 10**4
+    tol = 0.02
+
+    frequency_1 = mc.simulate(ts_length, random_state=seed).mean()
+    ok_(np.abs(frequency_1 - stationary_dist[1]) < tol)
 
 
 def test_simulate_for_matrices_with_C_F_orders():

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -224,13 +224,29 @@ def test_simulate_shape():
     assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
                        (ts_length,))
 
-    for (ts_length, init, num_reps) in [(10, [0, 1], None), (10, [0, 1], 3)]:
-        assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
-                           (len(init), ts_length))
+    (ts_length, init, num_reps) = (10, [0, 1], None)
+    assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
+                       (len(init), ts_length))
+
+    (ts_length, init, num_reps) = (10, [0, 1], 3)
+    assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
+                       (len(init)*num_reps, ts_length))
 
     for (ts_length, init, num_reps) in [(10, None, 3), (10, None, 1)]:
         assert_array_equal(mc.simulate(ts_length, init, num_reps).shape,
                            (num_reps, ts_length))
+
+
+def test_simulate_init_array_num_reps():
+    P = [[0.4, 0.6], [0.2, 0.8]]
+    mc = MarkovChain(P)
+
+    ts_length = 10
+    init=[0, 1]
+    num_reps=3
+
+    X = mc.simulate(ts_length, init, num_reps)
+    assert_array_equal(X[:, 0], init*num_reps)
 
 
 def test_simulate_ergodicity():

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -17,8 +17,6 @@ from quantecon.markov import (
     MarkovChain, mc_compute_stationary, mc_sample_path
 )
 
-from quantecon.util import numba_installed, jit
-
 
 def list_of_array_equal(s, t):
     """


### PR DESCRIPTION
This follows the discussions in #146.
(I hope I did "rebase" in the right way.)

0. I propose to change the `simulate` method as `simulate(ts_length, init=None, num_reps=None, random_state=None)`; see https://github.com/QuantEcon/QuantEcon.py/issues/146#issuecomment-109540676.
   * `init` now does not accept a distribution; see https://github.com/QuantEcon/QuantEcon.py/issues/146#issuecomment-117006253 and https://github.com/QuantEcon/QuantEcon.py/issues/146#issuecomment-117425074.

0. `random_state` option is added to `MarkovChain.simulate` (not to `MarkovChain.__init__`).

0. [`test_mc_sample_path`](https://github.com/QuantEcon/QuantEcon.py/blob/3ba9f53e3064385f2f852b820fa3ff2cef5a7083/quantecon/markov/tests/test_core.py#L259) is added with `random_state` specified.