### PR TITLE
Fix readthedocs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,8 +78,10 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'numpydoc',
-    'ipython_directive',
-    'ipython_console_highlighting',
+    # 'ipython_directive',
+    # 'ipython_console_highlighting',
+    'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive',
     'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
 ]

--- a/docs/source/markov.rst
+++ b/docs/source/markov.rst
@@ -6,6 +6,6 @@ Markov
 
    markov/approximation
    markov/core
+   markov/ddp
    markov/gth_solve
    markov/random
-   markov/ddp

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -4,11 +4,14 @@ Models
 .. toctree::
    :maxdepth: 2
 
+   models/arellano_vfi
    models/asset_pricing
    models/career
    models/ifp
    models/jv
+   models/lake
    models/lucastree
    models/odu
    models/optgrowth
+   models/uncertainty_traps
    solow/

--- a/docs/source/models/arellano_vfi.rst
+++ b/docs/source/models/arellano_vfi.rst
@@ -1,0 +1,7 @@
+arellano_vfi
+============
+
+.. automodule:: quantecon.models.arellano_vfi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/models/lake.rst
+++ b/docs/source/models/lake.rst
@@ -1,0 +1,7 @@
+lake
+====
+
+.. automodule:: quantecon.models.lake
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/models/uncertainty_traps.rst
+++ b/docs/source/models/uncertainty_traps.rst
@@ -1,0 +1,7 @@
+uncertainty_traps
+=================
+
+.. automodule:: quantecon.models.uncertainty_traps
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -7,13 +7,11 @@ Tools
    tools/arma
    tools/cartesian
    tools/ce_util
-   tools/common_messages
    tools/compute_fp
    tools/discrete_rv
    tools/distributions
    tools/ecdf
    tools/estspec
-   tools/external
    tools/graph_tools
    tools/gridtools
    tools/ivp
@@ -27,4 +25,3 @@ Tools
    tools/quadsums
    tools/rank_nullspace
    tools/robustlq
-   tools/timing

--- a/docs/source/util.rst
+++ b/docs/source/util.rst
@@ -5,4 +5,7 @@ Util
    :maxdepth: 2
 
    util/array
+   util/common_messages
+   util/external
    util/random
+   util/timing

--- a/docs/source/util/common_messages.rst
+++ b/docs/source/util/common_messages.rst
@@ -1,0 +1,7 @@
+common_messages
+===============
+
+.. automodule:: quantecon.util.common_messages
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/util/external.rst
+++ b/docs/source/util/external.rst
@@ -1,0 +1,7 @@
+external
+========
+
+.. automodule:: quantecon.util.external
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/util/timing.rst
+++ b/docs/source/util/timing.rst
@@ -1,0 +1,7 @@
+timing
+======
+
+.. automodule:: quantecon.util.timing
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Update importation of ``ipython_directive`` to be imported from Ipython project rather than local version. 

This also updates the ``rst`` files from the latest local build of html files. 