### PR TITLE
Fix NumbaWarning

### DIFF
--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -122,9 +122,36 @@ def sample_without_replacement(n, k, num_trials=None, random_state=None):
     random_state = check_random_state(random_state)
     r = random_state.random_sample(size=(m, k))
 
-    # Logic taken from random.sample in the standard library
-    result = np.empty((m, k), dtype=int)
-    pool = np.empty((m, n), dtype=int)
+    result = np.empty((m, k), dtype=int)  # Output array
+    pool = np.empty((m, n), dtype=int)  # Temporary array
+    _sample_without_replacement(n, k, m, r, pool, out=result)
+
+    if num_trials is None:
+        return result[0]
+    else:
+        return result
+
+
+@jit(nopython=True)
+def _sample_without_replacement(n, k, m, r, pool, out):
+    """
+    Main body of sample_without_replacement.
+    Logic taken from random.sample in the standard library.
+
+    Parameters
+    ----------
+    n, k, m : scalar(int)
+
+    r : ndarray(float, ndim=2)
+        Array containing random numbers in [0, 1). Shape (m, k).
+
+    pool : ndarray(int, ndim=2)
+        Temporary array. Shape (m, n).
+
+    out : ndarray(int, ndim=2)
+        Output array. Shape (m, k).
+
+    """
     for i in range(m):
         for j in range(n):
             pool[i, j] = j
@@ -132,15 +159,5 @@ def sample_without_replacement(n, k, num_trials=None, random_state=None):
     for i in range(m):
         for j in range(k):
             idx = int(np.floor(r[i, j] * (n-j)))  # np.floor returns a float
-            result[i, j] = pool[i, idx]
+            out[i, j] = pool[i, idx]
             pool[i, idx] = pool[i, n-j-1]
-
-    if num_trials is None:
-        return result[0]
-    else:
-        return result
-
-if numba_installed:
-    docs = sample_without_replacement.__doc__
-    sample_without_replacement = jit(sample_without_replacement)
-    sample_without_replacement.__doc__ = docs

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -123,7 +123,7 @@ def sample_without_replacement(n, k, num_trials=None, random_state=None):
     r = random_state.random_sample(size=(m, k))
 
     result = np.empty((m, k), dtype=int)  # Output array
-    pool = np.empty((m, n), dtype=int)  # Temporary array
+    pool = np.empty(n, dtype=int)  # Temporary array
     _sample_without_replacement(n, k, m, r, pool, out=result)
 
     if num_trials is None:
@@ -145,8 +145,8 @@ def _sample_without_replacement(n, k, m, r, pool, out):
     r : ndarray(float, ndim=2)
         Array containing random numbers in [0, 1). Shape (m, k).
 
-    pool : ndarray(int, ndim=2)
-        Temporary array. Shape (m, n).
+    pool : ndarray(int, ndim=1)
+        Temporary array. Shape (n,).
 
     out : ndarray(int, ndim=2)
         Output array. Shape (m, k).
@@ -154,10 +154,8 @@ def _sample_without_replacement(n, k, m, r, pool, out):
     """
     for i in range(m):
         for j in range(n):
-            pool[i, j] = j
-
-    for i in range(m):
+            pool[j] = j
         for j in range(k):
             idx = int(np.floor(r[i, j] * (n-j)))  # np.floor returns a float
-            out[i, j] = pool[i, idx]
-            pool[i, idx] = pool[i, n-j-1]
+            out[i, j] = pool[idx]
+            pool[idx] = pool[n-j-1]


### PR DESCRIPTION
This tries to fix one of the Numba warnings shown e.g. in Travis CI [421.2](https://travis-ci.org/QuantEcon/QuantEcon.py/jobs/81067437), on `sample_without_replacement` (although I haven't been able to reproduce the warning messages in my environment); see also #155.

The warning says Arg 3 (`random_state`) of `sample_without_replacement` is not legal in nopython mode. So I took the loops out as an independent function in nopython mode.

As a side effect, this should resolve item 2 in #170.