### PR TITLE
DiscreteDDP: minor fix in docstring and pep8 compliance

### DIFF
--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -708,12 +708,12 @@ class DiscreteDP(object):
         sigma = self.compute_greedy(v)
 
         res = DPSolveResult(v=v,
-                             sigma=sigma,
-                             num_iter=num_iter,
-                             mc=self.controlled_mc(sigma),
-                             method='value iteration',
-                             epsilon=epsilon,
-                             max_iter=max_iter)
+                            sigma=sigma,
+                            num_iter=num_iter,
+                            mc=self.controlled_mc(sigma),
+                            method='value iteration',
+                            epsilon=epsilon,
+                            max_iter=max_iter)
 
         return res
 
@@ -745,11 +745,11 @@ class DiscreteDP(object):
         num_iter = i + 1
 
         res = DPSolveResult(v=v_sigma,
-                             sigma=sigma,
-                             num_iter=num_iter,
-                             mc=self.controlled_mc(sigma),
-                             method='policy iteration',
-                             max_iter=max_iter)
+                            sigma=sigma,
+                            num_iter=num_iter,
+                            mc=self.controlled_mc(sigma),
+                            method='policy iteration',
+                            max_iter=max_iter)
 
         return res
 
@@ -798,13 +798,13 @@ class DiscreteDP(object):
         num_iter = i + 1
 
         res = DPSolveResult(v=v,
-                             sigma=sigma,
-                             num_iter=num_iter,
-                             mc=self.controlled_mc(sigma),
-                             method='modified policy iteration',
-                             epsilon=epsilon,
-                             max_iter=max_iter,
-                             k=k)
+                            sigma=sigma,
+                            num_iter=num_iter,
+                            mc=self.controlled_mc(sigma),
+                            method='modified policy iteration',
+                            epsilon=epsilon,
+                            max_iter=max_iter,
+                            k=k)
 
         return res
 

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Filename: ddp.py
 
 Author: Daisuke Oyama
@@ -141,7 +141,7 @@ class DiscreteDP(object):
 
        with parameters:
 
-       * length L reward vector R,
+       * length L reward vector `R`,
        * L x n transition probability array `Q`,
        * discount factor `beta`,
        * length L array `s_indices`, and
@@ -451,8 +451,8 @@ class DiscreteDP(object):
 
     def RQ_sigma(self, sigma):
         """
-        Given a policy `sigma`, return the reward vector R_sigma and the
-        transition probability matrix Q_sigma.
+        Given a policy `sigma`, return the reward vector `R_sigma` and
+        the transition probability matrix `Q_sigma`.
 
         Parameters
         ----------
@@ -483,7 +483,7 @@ class DiscreteDP(object):
     def bellman_operator(self, v, Tv=None, sigma=None):
         """
         The Bellman operator, which computes and returns the updated
-        value function Tv for a value function v.
+        value function `Tv` for a value function `v`.
 
         Parameters
         ----------
@@ -538,7 +538,7 @@ class DiscreteDP(object):
             Value function vector, of length n.
 
         sigma : ndarray(int, ndim=1), optional(default=None)
-            Optional output array for sigma.
+            Optional output array for `sigma`.
 
         Returns
         -------
@@ -820,7 +820,7 @@ class DiscreteDP(object):
         Returns
         -------
         mc : MarkovChain
-            Controlled Markov Chain.
+            Controlled Markov chain.
 
         """
         _, Q_sigma = self.RQ_sigma(sigma)


### PR DESCRIPTION
Sorry to make such a small fix.

* Looking at the [documentation](http://quanteconpy.readthedocs.org/en/latest/markov/ddp.html) of `DiscreteDP`, I realized that I had forgotten to add `r` at the beginning of the docstring that contains math expressions... An `r` is added now, and some minor edits are made in docstrings.

* Wrong indentation is fixed.