### PR TITLE
Fix P update in stationary coefficients.

### DIFF
--- a/quantecon/kalman.py
+++ b/quantecon/kalman.py
@@ -192,17 +192,21 @@ class Kalman(object):
         if K_infinity is None:
             S, K_infinity = self.stationary_values()
         # == compute and return coefficients == #
-        coeffs = [np.identity(self.ss.k)]
+        coeffs = []
         i = 1
         if coeff_type == 'ma':
-            P = A
+            coeffs.append(np.identity(self.ss.k))
+            P_mat = A
+            P = np.copy(P_mat)  # Create a copy
         elif coeff_type == 'var':
-            P = A - dot(K_infinity, G)
+            coeffs.append(dot(G, K_infinity))
+            P_mat = A - dot(K_infinity, G)
+            P = np.copy(P_mat)  # Create a copy
         else:
             raise ValueError("Unknown coefficient type")
         while i <= j:
             coeffs.append(dot(dot(G, P), K_infinity))
-            P = dot(P, P)
+            P = dot(P, P_mat)
             i += 1
         return coeffs
 


### PR DESCRIPTION
In the stationary coefficients for Kalman filter, update was being done with

```
P = Matrix
...
dot(P, P)
```

but this gives us P, P^2, P^4... instead of P, P^2, P^3...

Opening PR so John can make it prettier if he would like.