### PR TITLE
TRAVIS: set destination path for miniconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
+  - ./miniconda.sh -b -p /home/travis/miniconda
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
   - sudo rm -rf /dev/shm


### PR DESCRIPTION
Try to resolve "conda: command not found" as in #204.

Searching around in GitHub, I found [this](https://github.com/NVIDIA/caffe/pull/67), which I copy here. See what happens...