### PR TITLE
BUG: Fix bug in probvec

### DIFF
--- a/quantecon/markov/tests/test_random.py
+++ b/quantecon/markov/tests/test_random.py
@@ -81,6 +81,16 @@ def test_random_stochastic_matrix_dense_vs_sparse():
     assert_array_equal(P_dense, P_sparse.toarray())
 
 
+def test_random_stochastic_matrix_k_1():
+    n, k = 3, 1
+    P_dense = random_stochastic_matrix(n, k, sparse=False)
+    P_sparse = random_stochastic_matrix(n, k, sparse=True)
+    assert_array_equal(P_dense[P_dense != 0], np.ones(n))
+    assert_array_equal(P_sparse.data, np.ones(n))
+    for P in [P_dense, P_sparse]:
+        assert_array_almost_equal_nulp(P.sum(axis=1), np.ones(n))
+
+
 class TestRandomDiscreteDP:
     def setUp(self):
         self.num_states, self.num_actions = 5, 4

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -38,6 +38,10 @@ def probvec(m, k, random_state=None):
            [ 0.43772774,  0.34763084,  0.21464142]])
 
     """
+    if k == 1:
+        return np.ones((m, k))
+
+    # if k >= 2
     random_state = check_random_state(random_state)
     r = random_state.random_sample(size=(m, k-1))
 


### PR DESCRIPTION
Handle the case of `k=1` separately as in the [Julia version](https://github.com/QuantEcon/QuantEcon.jl/pull/80).