### PR TITLE
Adjust Travis-CI to run in python 3.5 and adjust pip classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 python:
   - 2.7
-  - 3.3
+  - 3.5
 
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: Scientific/Engineering',
 ]
 


### PR DESCRIPTION
This PR checks compatibility with Python ``3.5`` and makes necessary adjustments. 

Status: **Not** yet ready to merge