### PR TITLE
Add notebook autosetup and fetch utility for notebooks ...

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -28,7 +28,7 @@ from .markov import mc_compute_stationary, mc_sample_path 							#Imports that S
 from .rank_nullspace import rank_est, nullspace
 from .robustlq import RBLQ
 from . import quad as quad
-from .util import searchsorted
+from .util import searchsorted, fetch_nb_dependancies
 
 #Add Version Attribute
 from .version import version as __version__

--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -28,7 +28,7 @@ from .markov import mc_compute_stationary, mc_sample_path 							#Imports that S
 from .rank_nullspace import rank_est, nullspace
 from .robustlq import RBLQ
 from . import quad as quad
-from .util import searchsorted, fetch_nb_dependancies
+from .util import searchsorted, fetch_nb_dependencies
 
 #Add Version Attribute
 from .version import version as __version__

--- a/quantecon/util/__init__.py
+++ b/quantecon/util/__init__.py
@@ -4,6 +4,6 @@ API for QuantEcon Utilities
 
 from .array import searchsorted
 from .external import jit, numba_installed
-from .notebooks import fetch_nb_dependancies
+from .notebooks import fetch_nb_dependencies
 from .random import check_random_state
 from .timing import tic, tac, toc

--- a/quantecon/util/__init__.py
+++ b/quantecon/util/__init__.py
@@ -4,5 +4,6 @@ API for QuantEcon Utilities
 
 from .array import searchsorted
 from .external import jit, numba_installed
+from .notebooks import fetch_nb_dependancies
 from .random import check_random_state
 from .timing import tic, tac, toc

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -9,7 +9,7 @@ Note
 Files on the REMOTE Github Server can be organised into folders but they will end up at the root level of
 when downloaded as a support File
 
-"https://github.com/QuantEcon/QuantEcon.notebooks/raw/master/dependancies/mpi/something.py" --> ./somthing.py
+"https://github.com/QuantEcon/QuantEcon.notebooks/raw/master/dependencies/mpi/something.py" --> ./somthing.py
 
 TODO
 ----
@@ -26,9 +26,9 @@ import requests
 REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
 RAW = "raw"
 BRANCH = "master"
-DEPS = "dependancies"          #Hard Coded Dependancies Folder on QuantEcon.notebooks
+DEPS = "dependencies"          #Hard Coded Dependencies Folder on QuantEcon.notebooks
 
-def fetch_nb_dependancies(files, repo=REPO, raw=RAW, branch=BRANCH, deps=DEPS, verbose=True):
+def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, deps=DEPS, verbose=True):
     """
     Retrieve raw files from QuantEcon.notebooks Github repo
     

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -1,0 +1,65 @@
+"""
+Support functions to Support QuantEcon.notebooks
+
+The purpose of these utilities is to implement simple support functions to allow for automatic downloading
+of any support files (python modules, or data) that may be required to run demonstration notebooks.
+
+Note
+----
+Files on the REMOTE Github Server can be organised into folders but they will end up at the root level of
+when downloaded as a support File
+
+"https://github.com/QuantEcon/QuantEcon.notebooks/raw/master/dependancies/mpi/something.py" --> ./somthing.py
+
+TODO
+----
+1. Write Style guide for QuantEcon.notebook contributions
+2. Write an interface for Dat Server
+3. Platform Agnostic (replace wget usage)
+
+"""
+
+from invoke import run, task
+import os
+
+#-Remote Structure-#
+REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
+RAW = "raw"
+BRANCH = "master"
+DEPS = "dependancies"          #Hard Coded Dependancies Folder on QuantEcon.notebooks
+
+def fetch_nb_dependancies(files, repo=REPO, raw=RAW, branch=BRANCH, deps=DEPS, verbose=True):
+    """
+    Retrieve raw files from QuantEcon.notebooks Github repo
+    
+    Parameters
+    ----------
+    file_list   list or dict
+                A list of files to specify a collection of filenames
+                A dict of dir : list(files) to specify a directory
+    repo        str, optional(default=REPO)
+    branch      str, optional(default=BRANCH)
+    deps        str, optional(default=DEPS)
+    verbose     bool, optional(default=True)
+
+    TODO
+    ----
+    1. Should we update this to allow people to specify their own folders on a different GitHub repo?
+
+    """
+
+    #-Generate Common Data Structure-#
+    if type(files) == list:
+        files = {"" : files}
+
+    #-Obtain each requested file-#
+    for directory in files.keys():
+        if directory != "":
+            if verbose: print("Parsing directory: %s")
+        for fl in files[directory]:
+            if directory != "":
+                fl = directory+"/"+fl
+            if verbose: print("Fetching file: %s"%fl)
+            url = "/".join([repo,raw,branch,deps,fl])
+            run("wget %s"%url)
+

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -19,8 +19,8 @@ TODO
 
 """
 
-from invoke import run, task
 import os
+import requests
 
 #-Remote Structure-#
 REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
@@ -61,5 +61,7 @@ def fetch_nb_dependancies(files, repo=REPO, raw=RAW, branch=BRANCH, deps=DEPS, v
                 fl = directory+"/"+fl
             if verbose: print("Fetching file: %s"%fl)
             url = "/".join([repo,raw,branch,deps,fl])
-            run("wget %s"%url)
+            r = requests.get(url)
+            with open(fl, "wb") as fl:
+                fl.write(r.content)
 


### PR DESCRIPTION
This PR adds a simple utility for fetching dependencies (``*.py``) and data files (``*.csv``) from a GitHub repository. The defaults are set for use with **QuantEcon.notebooks**.

Example

```python
from quantecon import fetch_nb_dependencies
fetch_nb_dependencies(["Wald_Friedman_utils.py"])
```

but can be used with other repositories or branches etc. 

```python
#-Remote Structure-#
REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
RAW = "raw"
BRANCH = "master"
DEPS = "dependencies"          #Hard Coded Dependencies Folder on QuantEcon.notebooks

def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, deps=DEPS, verbose=True):
    """
    Retrieve raw files from QuantEcon.notebooks Github repo
    
    Parameters
    ----------
    file_list   list or dict
                A list of files to specify a collection of filenames
                A dict of dir : list(files) to specify a directory
    repo        str, optional(default=REPO)
    branch      str, optional(default=BRANCH)
    deps        str, optional(default=DEPS)
    verbose     bool, optional(default=True)

    TODO
    ----
    1. Should we update this to allow people to specify their own folders on a different GitHub repo?

    """
```

This will download the file from GitHub (QuantEcon.notebooks/master/dependencies/) directly - allowing a notebook to be run anywhere. This can also be done with data files etc.