### PR TITLE
Change converter functions to use default float

### DIFF
--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -100,7 +100,7 @@ class LQ(object):
 
     def __init__(self, Q, R, A, B, C=None, N=None, beta=1, T=None, Rf=None):
         # == Make sure all matrices can be treated as 2D arrays == #
-        converter = lambda X: np.atleast_2d(np.asarray(X, dtype='float32'))
+        converter = lambda X: np.atleast_2d(np.asarray(X, dtype='float'))
         self.A, self.B, self.Q, self.R, self.N = list(map(converter,
                                                           (A, B, Q, R, N)))
         # == Record dimensions == #
@@ -123,7 +123,7 @@ class LQ(object):
         if T:
             # == Model is finite horizon == #
             self.T = T
-            self.Rf = np.asarray(Rf, dtype='float32')
+            self.Rf = np.asarray(Rf, dtype='float')
             self.P = self.Rf
             self.d = 0
         else:

--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -141,7 +141,7 @@ class LinearStateSpace(object):
         well formed 2D NumPy arrays
 
         """
-        return np.atleast_2d(np.asarray(x, dtype='float32'))
+        return np.atleast_2d(np.asarray(x, dtype='float'))
 
     def simulate(self, ts_length=100):
         """


### PR DESCRIPTION
I don't know if there was an original reason for using `"float32"` in our converter functions, but it might be nice to use the system default. Opening this to see what people think -- I'd rather use system default.

```
In [7]: x = np.random.randn(25)

In [8]: np.asarray(x, dtype="float32").dtype
Out[8]: dtype('float32')

In [9]: np.asarray(x, dtype="float64").dtype
Out[9]: dtype('float64')

In [10]: np.asarray(x, dtype="float").dtype
Out[10]: dtype('float64')
```