### PR TITLE
Add `distributions` to quantecon/__init__.py

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -8,6 +8,7 @@ except:
 	raise ImportError("Cannot import numba from current anaconda distribution. Please run `conda install numba` to install the latest version.")
 
 #-Modules-#
+from . import distributions
 from . import quad
 from . import random
 


### PR DESCRIPTION
Fixes QuantEcon/QuantEcon.notebooks#21.

(`models/career.py` used to have `from quantecon.distributions import BetaBinomial` which made `quantecon.distributions` importable without `from . import distributions` in `__init__.py`, but `models` has now gone.)