### PR TITLE
Changes in normal_form_game

### DIFF
--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -507,11 +507,9 @@ class NormalFormGame(object):
                         dtype=self.dtype)
 
     def __str__(self):
-        s = '{nums_actions} {N}-player NormalFormGame'
-        s += ' with payoff profile array:\n'
+        s = '{N}-player NormalFormGame with payoff profile array:\n'
         s += _payoff_profile_array2string(self.payoff_profile_array)
-        return s.format(nums_actions=_nums_actions2string(self.nums_actions),
-                        N=self.N)
+        return s.format(N=self.N)
 
     def __getitem__(self, action_profile):
         if self.N == 1:  # Trivial game with 1 player

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -175,12 +175,18 @@ class Player(object):
         self.tol = 1e-8
 
     def __repr__(self):
-        N = self.num_opponents + 1
-        s = 'Player in a {N}-player normal form game'.format(N=N)
-        return s
+        # From numpy.matrix.__repr__
+        # Print also dtype, except for int64, float64
+        s = repr(self.payoff_array).replace('array', 'Player')
+        l = s.splitlines()
+        for i in range(1, len(l)):
+            if l[i]:
+                l[i] = ' ' + l[i]
+        return '\n'.join(l)
 
     def __str__(self):
-        s = self.__repr__()
+        N = self.num_opponents + 1
+        s = 'Player in a {N}-player normal form game'.format(N=N)
         s += ' with payoff array:\n'
         s += np.array2string(self.payoff_array, separator=', ')
         return s
@@ -591,15 +597,6 @@ class NormalFormGame(object):
                 return False
 
         return True
-
-
-def _payoff_array2string(payoff_array, class_name=None):
-    prefix, suffix = '', ''
-    if class_name is not None:
-        prefix = class_name + '('
-        suffix = ')'
-    s = np.array2string(payoff_array, separator=', ', prefix=prefix)
-    return prefix + s + suffix
 
 
 def _payoff_profile_array2string(payoff_profile_array, class_name=None):

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -501,14 +501,17 @@ class NormalFormGame(object):
         return payoff_profile_array
 
     def __repr__(self):
-        s = '{N}-player NormalFormGame'.format(N=self.N)
-        return s
+        s = '<{nums_actions} {N}-player NormalFormGame of dtype {dtype}>'
+        return s.format(nums_actions=_nums_actions2string(self.nums_actions),
+                        N=self.N,
+                        dtype=self.dtype)
 
     def __str__(self):
-        s = self.__repr__()
+        s = '{nums_actions} {N}-player NormalFormGame'
         s += ' with payoff profile array:\n'
         s += _payoff_profile_array2string(self.payoff_profile_array)
-        return s
+        return s.format(nums_actions=_nums_actions2string(self.nums_actions),
+                        N=self.N)
 
     def __getitem__(self, action_profile):
         if self.N == 1:  # Trivial game with 1 player
@@ -597,6 +600,14 @@ class NormalFormGame(object):
                 return False
 
         return True
+
+
+def _nums_actions2string(nums_actions):
+    if len(nums_actions) == 1:
+        s = '{0}-action'.format(nums_actions[0])
+    else:
+        s = 'x'.join(map(str, nums_actions))
+    return s
 
 
 def _payoff_profile_array2string(payoff_profile_array, class_name=None):

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -517,12 +517,12 @@ class NormalFormGame(object):
         except TypeError:
             raise TypeError('index must be a tuple')
 
-        payoff_profile = [
-            player.payoff_array[
-                tuple(action_profile[i:]) + tuple(action_profile[:i])
-            ]
-            for i, player in enumerate(self.players)
-        ]
+        payoff_profile = np.empty(self.N, dtype=self.dtype)
+        for i, player in enumerate(self.players):
+            payoff_profile[i] = \
+                player.payoff_array[
+                    tuple(action_profile[i:]) + tuple(action_profile[:i])
+                ]
 
         return payoff_profile
 

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -323,6 +323,13 @@ def test_normalformgame_invalid_input_players_num_inconsistent():
 
 
 @raises(ValueError)
+def test_normalformgame_invalid_input_players_dtype_inconsistent():
+    p0 = Player(np.zeros((2, 2), dtype=int))
+    p1 = Player(np.zeros((2, 2), dtype=float))
+    g = NormalFormGame([p0, p1])
+
+
+@raises(ValueError)
 def test_normalformgame_invalid_input_nosquare_matrix():
     g = NormalFormGame(np.zeros((2, 3)))
 

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -306,6 +306,21 @@ def test_normalformgame_setitem_1p():
     eq_(g.players[0].payoff_array[0], 10)
 
 
+# Test __repre__ #
+
+def test_player_repr():
+    nums_actions = (2, 3, 4)
+    payoff_arrays = [
+        np.arange(np.prod(nums_actions[0:i])).reshape(nums_actions[0:i])
+        for i in range(1, len(nums_actions)+1)
+    ]
+    players = [Player(payoff_array) for payoff_array in payoff_arrays]
+
+    for player in players:
+        player_new = eval(repr(player))
+        assert_array_equal(player_new.payoff_array, player.payoff_array)
+
+
 # Invalid inputs #
 
 @raises(ValueError)


### PR DESCRIPTION
Relatively minor changes:

1.
`NormalFormGame` now requires the `Player` instances to be homogeneous in `dtype` (as in the [Julia version](https://github.com/QuantEcon/QuantEcon.jl/pull/95)).

2.
`NormalFormGame.__getitem__` returns an `ndarray` of the common `dtype` (previously, it was `list`).

3.
`Player.__repr__` has been changed:

```python
>>> player = Player([[4, 0], [3, 2]])
>>> player
Player([[4, 0],
        [3, 2]])
```

(`NormalFormGame.__repr__` kept unchanged. Constructing a payoff profile array is costly, so it is printed by an explicit call of `print`.)