### PR TITLE
Remove warnings supression as noted by Issue #229

### DIFF
--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -4,16 +4,13 @@ Authors: Doc-Jin Jang, Jerry Choi, Thomas Sargent, John Stachurski
 
 Provides functions for working with and visualizing scalar ARMA processes.
 
+TODO: 1. Fix warnings concerning casting complex variables back to floats
+
 """
 import numpy as np
 from numpy import conj, pi
 import matplotlib.pyplot as plt
 from scipy.signal import dimpulse, freqz, dlsim
-
-# == Ignore unnecessary warnings concerning casting complex variables back to
-# floats == #
-import warnings
-warnings.filterwarnings('ignore')
 
 
 class ARMA(object):

--- a/quantecon/matrix_eqn.py
+++ b/quantecon/matrix_eqn.py
@@ -7,9 +7,9 @@ equations.  Currently has functionality to solve:
 * Lyapunov Equations
 * Ricatti Equations
 
-TODO: See issue 47 on github repository, should add support for
+TODO: 1. See issue 47 on github repository, should add support for
       Sylvester equations
-
+      2. Fix warnings from checking conditioning of matrices
 """
 from __future__ import division
 import numpy as np
@@ -17,9 +17,6 @@ import warnings
 from numpy import dot
 from numpy.linalg import solve
 from scipy.linalg import solve_discrete_lyapunov as sp_solve_discrete_lyapunov
-
-# == Suppress warnings from checking conditioning of matrices == #
-warnings.simplefilter("ignore", RuntimeWarning)
 
 
 def solve_discrete_lyapunov(A, B, max_it=50, method="doubling"):

--- a/quantecon/matrix_eqn.py
+++ b/quantecon/matrix_eqn.py
@@ -13,7 +13,6 @@ TODO: 1. See issue 47 on github repository, should add support for
 """
 from __future__ import division
 import numpy as np
-import warnings
 from numpy import dot
 from numpy.linalg import solve
 from scipy.linalg import solve_discrete_lyapunov as sp_solve_discrete_lyapunov


### PR DESCRIPTION
This PR removes the warning supression from `arma.py` and `matrix_eqn.py`.

**TODO:** The next step is to fix the underlying cause of the warning. 
