### PR TITLE
Update name of Game Theory for cleaner look

### DIFF
--- a/docs/qe_apidoc.py
+++ b/docs/qe_apidoc.py
@@ -272,9 +272,12 @@ def model_tool():
 
     for f_name in ("game_theory", "markov", "random", "tools", "util"):
         with open(source_join(f_name + ".rst"), "w") as f:
+            m_name = f_name
+            if f_name == "game_theory":
+                f_name = "Game Theory"                                             #Produce Nicer Title for Game Theory Module
             temp = split_file_template.format(name=f_name.capitalize(),
                                               equals="="*len(f_name),
-                                              files=toc_tree_list[f_name])
+                                              files=toc_tree_list[m_name])
             f.write(temp)
 
 if __name__ == '__main__':

--- a/docs/source/game_theory.rst
+++ b/docs/source/game_theory.rst
@@ -1,4 +1,4 @@
-Game_theory
+Game theory
 ===========
 
 .. toctree::


### PR DESCRIPTION
Simple update to improve the title of the game theory module in the documentation.

``Game_theory`` to ``Game theory``