### PR TITLE
MarkovChain: Bug fix in _compute_stationary with state_values

### DIFF
--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -405,7 +405,7 @@ class MarkovChain(object):
                     gth_solve(self.P.toarray(),
                               overwrite=True).reshape(1, self.n)
         else:
-            rec_classes = self.recurrent_classes
+            rec_classes = self.recurrent_classes_indices
             stationary_dists = np.zeros((len(rec_classes), self.n))
             for i, rec_class in enumerate(rec_classes):
                 if not self.is_sparse:  # Dense

--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -479,6 +479,15 @@ class TestMCStateValues:
             assert_array_equal(X, X_expected)
 
 
+def test_mc_stationary_distributions_state_values():
+    P = [[0.4, 0.6, 0], [0.2, 0.8, 0], [0, 0, 1]]
+    state_values = ['a', 'b', 'c']
+    mc = MarkovChain(P, state_values=state_values)
+    stationary_dists_expected = [[0.25, 0.75, 0], [0, 0, 1]]
+    stationary_dists = mc.stationary_distributions
+    assert_allclose(stationary_dists, stationary_dists_expected)
+
+
 def test_get_index():
     P = [[0.4, 0.6], [0.2, 0.8]]
     mc = MarkovChain(P)


### PR DESCRIPTION
I forgot to change `recurrent_classes` to `recurrent_classes_indices`.