### PR TITLE
probvec: Use guvectorize with target='parallel'

### DIFF
--- a/quantecon/random/tests/test_utilities.py
+++ b/quantecon/random/tests/test_utilities.py
@@ -3,13 +3,33 @@ Tests for util/random.py
 
 Functions
 ---------
+probvec
 sample_without_replacement
 
 """
 import numpy as np
 from numpy.testing import assert_array_equal, assert_raises
 from nose.tools import eq_
-from quantecon.random import sample_without_replacement
+from quantecon.random import probvec, sample_without_replacement
+
+
+# probvec #
+
+class TestProbvec:
+    def setUp(self):
+        self.m, self.k = 2, 3  # m vectors of dimension k
+        seed = 1234
+
+        self.out_parallel = probvec(self.m, self.k, random_state=seed)
+        self.out_cpu = \
+            probvec(self.m, self.k, random_state=seed, parallel=False)
+
+    def test_shape(self):
+        for out in [self.out_parallel, self.out_cpu]:
+            eq_(out.shape, (self.m, self.k))
+
+    def test_parallel_cpu(self):
+        assert_array_equal(self.out_parallel, self.out_cpu)
 
 
 # sample_without_replacement #

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -29,6 +29,11 @@ def probvec(m, k, random_state=None, parallel=True):
         reproducibility. If None, a randomly initialized RandomState is
         used.
 
+    parallel : bool(default=True)
+        Whether to use multi-core CPU (parallel=True) or single-threaded
+        CPU (parallel=False). (Internally the code is executed through
+        Numba.guvectorize.)
+
     Returns
     -------
     x : ndarray(float, ndim=2)
@@ -48,7 +53,8 @@ def probvec(m, k, random_state=None, parallel=True):
     random_state = check_random_state(random_state)
     r = random_state.random_sample(size=(m, k-1))
     x = np.empty((m, k))
-    #-Parse Parallel Option-#
+
+    # Parse Parallel Option #
     if parallel:
         _probvec_parallel(r, x)
     else:
@@ -61,10 +67,10 @@ def _probvec(r, out):
     """
     Fill `out` with randomly sampled probability vectors as rows.
 
-    Complied as a ufunc by guvectorize of Numba. The inputs must have
-    the same shape except the last axis; the length of the last axis of
-    `r` must be that of `out` minus 1, i.e., if out.shape[-1] is k, then
-    r.shape[-1] must be k-1.
+    To be complied as a ufunc by guvectorize of Numba. The inputs must
+    have the same shape except the last axis; the length of the last
+    axis of `r` must be that of `out` minus 1, i.e., if out.shape[-1] is
+    k, then r.shape[-1] must be k-1.
 
     Parameters
     ----------
@@ -82,8 +88,12 @@ def _probvec(r, out):
         out[i] = r[i] - r[i-1]
     out[n] = 1 - r[n-1]
 
-_probvec_parallel = guvectorize(['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='parallel')(_probvec)
-_probvec_cpu = guvectorize(['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='cpu')(_probvec)
+_probvec_parallel = guvectorize(
+    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='parallel'
+    )(_probvec)
+_probvec_cpu = guvectorize(
+    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='cpu'
+    )(_probvec)
 
 
 @jit


### PR DESCRIPTION
This is to modify `probvec` to use [`guvectorize`](http://numba.pydata.org/numba-doc/dev/user/vectorize.html#the-guvectorize-decorator) with `target='parallel'`.
(`probvec` is mainly used to generate samples of `MarkovChain` or `DiscreteDP`.)

* Use of `guvectorize` simplifies the logic slightly; we don't need to explicitly write the outer loop.
* This version puts `sort()` in a jitted loop with nopython mode, the bottleneck of [the current `probvec`](https://github.com/QuantEcon/QuantEcon.py/blob/05d72ce1cb6a24317838909b019c9f711ccad61f/quantecon/random/utilities.py#L50).
* [Sorting by Numba may be slower than Numpy](http://numba.pydata.org/numba-doc/0.25.0/reference/numpysupported.html#other-methods), but with `target='parallel'` this version is faster than the current version on `master` for cases with large size, whereas it seems slower with small size (probably due to overhead).

Timing on a machine with 4 cores:

`master`:

```python
In [1]: import quantecon as qe

In [2]: seed = 1234

In [3]: m, k = 5000, 5000

In [4]: %timeit qe.random.probvec(m, k, random_state=seed)
1 loop, best of 3: 1.63 s per loop

In [5]: beta = 0.95

In [6]: num_states, num_actions = 500, 100

In [7]: %timeit qe.markov.random_discrete_dp(num_states, num_actions, beta, random_state=seed)
1 loop, best of 3: 1.45 s per loop
```

This version:

```python
In [1]: import quantecon as qe

In [2]: seed = 1234

In [3]: m, k = 5000, 5000

In [4]: %timeit qe.random.probvec(m, k, random_state=seed)
1 loop, best of 3: 681 ms per loop

In [5]: beta = 0.95

In [6]: num_states, num_actions = 500, 100

In [7]: %timeit qe.markov.random_discrete_dp(num_states, num_actions, beta, random_state=seed)
1 loop, best of 3: 747 ms per loop
```

This is the first case in quantecon where `guvectorize` is used; we might discuss its pros and cons here.