### PR TITLE
Update to version 0.3.3

### DIFF
--- a/quantecon/version.py
+++ b/quantecon/version.py
@@ -1,4 +1,4 @@
 """
 This is a VERSION file and should NOT be manually altered
 """
-version = '0.3.2'
+version = '0.3.3'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 #-Write Versions File-#
 #~~~~~~~~~~~~~~~~~~~~~#
 
-VERSION = '0.3.2'
+VERSION = '0.3.3'
 
 def write_version_py(filename=None):
     """
@@ -81,9 +81,7 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
     'Topic :: Scientific/Engineering',
 ]
@@ -109,5 +107,6 @@ setup(name='quantecon',
       author='Thomas J. Sargent and John Stachurski (Project coordinators)',
       author_email='john.stachurski@gmail.com',
       url='https://github.com/QuantEcon/QuantEcon.py',  # URL to the repo
+      download_url='https://github.com/QuantEcon/QuantEcon.py/tarball/' + VERSION, 
       keywords=['quantitative', 'economics']
       )


### PR DESCRIPTION
This PR updates to version 0.3.3 which includes

  1. Remove ``python2.7`` classifiers as it is a ``python3.5+`` project. 
  2. Migrates ``sa_indices`` to be a utility function for the markov submodule
  3. Updates ``probvec`` to include a multi-core parallel option using numba infrastructure in ``quantecon/random/utilities.py``.

This includes some minor house cleaning to incorporate the package in ``conda-forge``