### PR TITLE
Player, NormalFormGame: Make `payoff_array`'s C contiguous

### DIFF
--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -475,11 +475,16 @@ class NormalFormGame(object):
                         'size of innermost array must be equal to ' +
                         'the number of players'
                     )
-                self.players = tuple(
-                    Player(
+                payoff_arrays = tuple(
+                    np.empty(data.shape[i:-1]+data.shape[:i], dtype=data.dtype)
+                    for i in range(N)
+                )
+                for i, payoff_array in enumerate(payoff_arrays):
+                    payoff_array[:] = \
                         data.take(i, axis=-1).transpose(list(range(i, N)) +
                                                         list(range(i)))
-                    ) for i in range(N)
+                self.players = tuple(
+                    Player(payoff_array) for payoff_array in payoff_arrays
                 )
                 self.dtype = data.dtype
 

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -163,7 +163,7 @@ class Player(object):
 
     """
     def __init__(self, payoff_array):
-        self.payoff_array = np.asarray(payoff_array)
+        self.payoff_array = np.asarray(payoff_array, order='C')
 
         if self.payoff_array.ndim == 0:
             raise ValueError('payoff_array must be an array_like')

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -236,6 +236,16 @@ def test_normalformgame_payoff_profile_array():
             assert_array_equal(player_new.payoff_array, payoff_array)
 
 
+def test_normalformgame_payoff_profile_array_c_contiguous():
+    nums_actions = (2, 3, 4)
+    shape = nums_actions + (len(nums_actions),)
+    payoff_profile_array = \
+        np.arange(np.prod(shape)).reshape(shape)
+    g = NormalFormGame(payoff_profile_array)
+    for player in g.players:
+        ok_(player.payoff_array.flags['C_CONTIGUOUS'])
+
+
 # Trivial cases with one player #
 
 class TestPlayer_0opponents:


### PR DESCRIPTION
Make `payoff_array`'s C contiguous when when a `payoff_profile_array` is passed to `NormalFormGame`, in order for Numba not to complain.
