### PR TITLE
Add brute force method for finding pure nash equilibria.

### DIFF
--- a/quantecon/game_theory/__init__.py
+++ b/quantecon/game_theory/__init__.py
@@ -7,3 +7,4 @@ from .normal_form_game import pure2mixed, best_response_2p
 from .random import random_game, covariance_game
 from .support_enumeration import support_enumeration, support_enumeration_gen
 from .lemke_howson import lemke_howson
+from .pure_nash import pure_nash_brute

--- a/quantecon/game_theory/pure_nash.py
+++ b/quantecon/game_theory/pure_nash.py
@@ -1,0 +1,65 @@
+"""
+Author: Zejin Shi
+
+Methods for computing pure Nash equilibria of a normal form game.
+(For now, only brute force method is supported)
+
+"""
+
+import numpy as np
+
+
+def pure_nash_brute(g):
+    """
+    Find all pure Nash equilibria of a normal form game by brute force.
+
+    Parameters
+    ----------
+    g : NormalFormGame
+
+    Returns
+    -------
+    NEs : list(tuple(int))
+        List of tuples of Nash equilibrium pure actions.
+        If no pure Nash equilibrium is found, return empty list.
+
+    Examples
+    --------
+    Consider the "Prisoners' Dilemma" game:
+
+    >>> PD_bimatrix = [[(1, 1), (-2, 3)],
+    ...                [(3, -2), (0, 0)]]
+    >>> g_PD = NormalFormGame(PD_bimatrix)
+    >>> pure_nash_brute(g_PD)
+    [(1, 1)]
+
+    If we consider the "Matching Pennies" game, which has no pure nash
+    equilibirum:
+
+    >>> MP_bimatrix = [[(1, -1), (-1, 1)],
+    ...                [(-1, 1), (1, -1)]]
+    >>> g_MP = NormalFormGame(MP_bimatrix)
+    >>> pure_nash_brute(g_MP)
+    []
+
+    """
+    return list(pure_nash_brute_gen(g))
+
+
+def pure_nash_brute_gen(g):
+    """
+    Generator version of `pure_nash_brute`.
+
+    Parameters
+    ----------
+    g : NormalFormGame
+
+    Yields
+    ------
+    out : tuple(int)
+        Tuple of Nash equilibrium pure actions.
+
+    """
+    for a in np.ndindex(*g.nums_actions):
+        if g.is_nash(a):
+            yield a

--- a/quantecon/game_theory/tests/test_pure_nash.py
+++ b/quantecon/game_theory/tests/test_pure_nash.py
@@ -1,0 +1,68 @@
+"""
+Author: Zejin Shi
+
+Tests for pure_nash.py
+
+"""
+
+import numpy as np
+import itertools
+from nose.tools import eq_
+from quantecon.game_theory import NormalFormGame, pure_nash_brute
+
+
+class TestPureNashBruteForce():
+    def setUp(self):
+        self.game_dicts = []
+
+        # Matching Pennies game with no pure nash equilibrium
+        MP_bimatrix = [[(1, -1), (-1, 1)],
+                       [(-1, 1), (1, -1)]]
+        MP_NE = []
+
+        # Prisoners' Dilemma game with one pure nash equilibrium
+        PD_bimatrix = [[(1, 1), (-2, 3)],
+                       [(3, -2), (0, 0)]]
+        PD_NE = [(1, 1)]
+
+        # Battle of the Sexes game with two pure nash equilibria
+        BoS_bimatrix = [[(3, 2), (1, 0)],
+                        [(0, 1), (2, 3)]]
+        BoS_NE = [(0, 0), (1, 1)]
+
+        # Unanimity Game with more than two players
+        N = 4
+        a, b = 1, 2
+        g_Unanimity = NormalFormGame((2,)*N)
+        g_Unanimity[(0,)*N] = (a,)*N
+        g_Unanimity[(1,)*N] = (b,)*N
+
+        Unanimity_NE = [(0,)*N]
+        for k in range(2, N-2+1):
+            for ind in itertools.combinations(range(N), k):
+                a = np.ones(N, dtype=int)
+                a[[ind]] = 0
+                Unanimity_NE.append(tuple(a))
+        Unanimity_NE.append((1,)*N)
+
+        for bimatrix, NE in zip([MP_bimatrix, PD_bimatrix, BoS_bimatrix],
+                                [MP_NE, PD_NE, BoS_NE]):
+            d = {'g': NormalFormGame(bimatrix),
+                 'NEs': NE}
+            self.game_dicts.append(d)
+        self.game_dicts.append({'g': g_Unanimity,
+                                'NEs': Unanimity_NE})
+
+    def test_brute_force(self):
+        for d in self.game_dicts:
+            eq_(sorted(pure_nash_brute(d['g'])), sorted(d['NEs']))
+
+
+if __name__ == '__main__':
+    import sys
+    import nose
+
+    argv = sys.argv[:]
+    argv.append('--verbose')
+    argv.append('--nocapture')
+    nose.main(argv=argv, defaultTest=__file__)


### PR DESCRIPTION
Based on #266.

Add a function `pure_nash_brute` to find all pure nash equilibria of a normal form game using brute force method. 

For example, consider the Prisoners' Dilemma game. 
```
>>> PD_bimatrix = [[(1, 1), (-2, 3)],
...                [(3, -2), (0, 0)]]
>>> g_PD = NormalFormGame(PD_bimatrix)
>>> pure_nash_brute(g_PD)
[(1, 1)]
```

Mainly referred to [Tools for Game Theory](http://nbviewer.jupyter.org/github/QuantEcon/QuantEcon.notebooks/blob/master/game_theory_py.ipynb). @oyamad 