### PR TITLE
FIX: support_enumeration: Disable cache in _indiff_mixed_action

### DIFF
--- a/quantecon/game_theory/support_enumeration.py
+++ b/quantecon/game_theory/support_enumeration.py
@@ -129,7 +129,7 @@ def _support_enumeration_gen(payoff_matrix0, payoff_matrix1):
             next_k_array(supps[0])
 
 
-@jit(nopython=nopython, cache=True)
+@jit(nopython=nopython)
 def _indiff_mixed_action(payoff_matrix, own_supp, opp_supp, A, b, out):
     """
     Given a player's payoff matrix `payoff_matrix`, an array `own_supp`


### PR DESCRIPTION
Remove `cache=True` in a jitted function for `support_enumeration`.

The kernel dies if a notebook with `support_enumeration` is executed by `Run All`. After this event, Python always dies with `support_enumeration` with a message

```
LLVM ERROR: Program used external function '_numba.targets.arraymath.np_any.<locals>.flat_any$26.array(bool,_1d,_C)' which could not be resolved!
```

This does not happen once `cache=True` is removed from `_indiff_mixed_action`.