### PR TITLE
remove specific version of quantecon from rtd environment

### DIFF
--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -55,6 +55,6 @@ dependencies:
 - zlib=1.2.8=0
 - pip:
   - ipython-genutils==0.1.0
-  - quantecon==0.3.1
+  - quantecon
   - sphinx-rtd-theme==0.1.9
 


### PR DESCRIPTION
this PR removes the version of quantecon from rtd-environment so that it loads the latest version. 

- check if this fixes our current rtd issue with rendering some lectures.