### PR TITLE
adjust coveragerc to skip @jit functions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -28,3 +28,4 @@ exclude_lines =
 
     # Don't count Numba nopython=True jit functions
     @jit\(.*nopython=True
+    @njit

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,24 @@ omit =
     */site-packages/ordereddict.py
     */site-packages/nose/*
     */unittest2/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Don't count Numba Jit Functions
+    @jit

--- a/.coveragerc
+++ b/.coveragerc
@@ -26,5 +26,5 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
-    # Don't count Numba Jit Functions
-    @jit
+    # Don't count Numba nopython=True jit functions
+    @jit\(.*nopython=True


### PR DESCRIPTION
This PR adjusts the coverage rc file to adopt custom regex exclusions to make ``coverage`` statistics more useful in diagnosing code that isn't covered by tests. 

This will help with PR #302 