### PR TITLE
fix compatibility with pandas v0.2

### DIFF
--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -10,7 +10,7 @@ Functions for working with periodograms of scalar data.
 from __future__ import division, print_function
 import numpy as np
 from numpy.fft import fft
-import statsmodels.api as sm
+from statsmodels.api.tsa import AR
 
 
 def smooth(x, window_len=7, window='hanning'):
@@ -140,7 +140,7 @@ def ar_periodogram(x, window='hanning', window_len=7):
 
     """
     # === run regression === #
-    results = sm.tsa.AR(x).fit(maxlag=1, cov_type='HAC', cov_kwds={'maxlags':1})
+    results = AR(x).fit(maxlag=1, cov_type='HAC', cov_kwds={'maxlags':1})
     e_hat = results.resid
     phi = results.params[1]
 

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -10,7 +10,8 @@ Functions for working with periodograms of scalar data.
 from __future__ import division, print_function
 import numpy as np
 from numpy.fft import fft
-from pandas import ols, Series
+from pandas import DataFrame
+import statsmodels.api as sm
 
 
 def smooth(x, window_len=7, window='hanning'):
@@ -140,11 +141,9 @@ def ar_periodogram(x, window='hanning', window_len=7):
 
     """
     # === run regression === #
-    x_current, x_lagged = x[1:], x[:-1]  # x_t and x_{t-1}
-    x_current, x_lagged = Series(x_current), Series(x_lagged)  # pandas series
-    results = ols(y=x_current, x=x_lagged, intercept=True, nw_lags=1)
-    e_hat = results.resid.values
-    phi = results.beta['x']
+    results = sm.tsa.AR(x).fit(maxlag=1, cov_type='HAC', cov_kwds={'maxlags':1})
+    e_hat = results.resid
+    phi = results.params[1]
 
     # === compute periodogram on residuals === #
     w, I_w = periodogram(e_hat, window=window, window_len=window_len)

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -10,7 +10,7 @@ Functions for working with periodograms of scalar data.
 from __future__ import division, print_function
 import numpy as np
 from numpy.fft import fft
-from statsmodels.api.tsa import AR
+from statsmodels.api import tsa
 
 
 def smooth(x, window_len=7, window='hanning'):
@@ -140,7 +140,7 @@ def ar_periodogram(x, window='hanning', window_len=7):
 
     """
     # === run regression === #
-    results = AR(x).fit(maxlag=1, cov_type='HAC', cov_kwds={'maxlags':1})
+    results = tsa.AR(x).fit(maxlag=1, cov_type='HAC', cov_kwds={'maxlags':1})
     e_hat = results.resid
     phi = results.params[1]
 

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -10,7 +10,6 @@ Functions for working with periodograms of scalar data.
 from __future__ import division, print_function
 import numpy as np
 from numpy.fft import fft
-from pandas import DataFrame
 import statsmodels.api as sm
 
 


### PR DESCRIPTION
- this PR removes the ols import from pandas, which has been deprecated in pandas v0.2 and is causing the quantecon package to break
- I've used the statsmodels time series module to estimate the ar1
- I was using the lecture solutions to test the code, but this includes a simulation so I can't exactly replicate the output - would someone be able to check this gives correct results?
- I'm not sure why Newey-West covariance matrix is used, but I've included it