### PR TITLE
FIX: support_enumeration: Use `_numba_linalg_solve`

### DIFF
--- a/docs/source/util.rst
+++ b/docs/source/util.rst
@@ -7,5 +7,6 @@ Utilities
    util/array
    util/common_messages
    util/notebooks
+   util/numba
    util/random
    util/timing

--- a/docs/source/util/numba.rst
+++ b/docs/source/util/numba.rst
@@ -1,0 +1,7 @@
+numba
+=====
+
+.. automodule:: quantecon.util.numba
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/quantecon/game_theory/support_enumeration.py
+++ b/quantecon/game_theory/support_enumeration.py
@@ -110,7 +110,7 @@ def _support_enumeration_gen(payoff_matrix0, payoff_matrix1):
             _next_k_array(supps[0])
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _indiff_mixed_action(payoff_matrix, own_supp, opp_supp, A, out):
     """
     Given a player's payoff matrix `payoff_matrix`, an array `own_supp`
@@ -161,8 +161,9 @@ def _indiff_mixed_action(payoff_matrix, own_supp, opp_supp, A, out):
     r = _numba_linalg_solve(A, out)
     if r != 0:  # A: singular
         return False
-    if (out[:-1] <= 0).any():
-        return False
+    for i in range(k):
+        if out[i] <= 0:
+            return False
     val = out[-1]
 
     if k == m:

--- a/quantecon/game_theory/tests/test_support_enumeration.py
+++ b/quantecon/game_theory/tests/test_support_enumeration.py
@@ -6,6 +6,7 @@ Tests for support_enumeration.py
 """
 import numpy as np
 from numpy.testing import assert_allclose
+from nose.tools import eq_
 from quantecon.util import check_random_state
 from quantecon.game_theory import Player, NormalFormGame, support_enumeration
 
@@ -57,6 +58,7 @@ class TestSupportEnumeration():
     def test_support_enumeration(self):
         for d in self.game_dicts:
             NEs_computed = support_enumeration(d['g'])
+            eq_(len(NEs_computed), len(d['NEs']))
             for actions_computed, actions in zip(NEs_computed, d['NEs']):
                 for action_computed, action in zip(actions_computed, actions):
                     assert_allclose(action_computed, action)

--- a/quantecon/game_theory/tests/test_support_enumeration.py
+++ b/quantecon/game_theory/tests/test_support_enumeration.py
@@ -4,8 +4,30 @@ Author: Daisuke Oyama
 Tests for support_enumeration.py
 
 """
+import numpy as np
 from numpy.testing import assert_allclose
+from quantecon.util import check_random_state
 from quantecon.game_theory import Player, NormalFormGame, support_enumeration
+
+
+def random_skew_sym(n, m=None, random_state=None):
+    """
+    Generate a random skew symmetric zero-sum NormalFormGame of the form
+    O    B
+    -B.T O
+    where B is an n x m matrix.
+
+    """
+    if m is None:
+        m = n
+    random_state = check_random_state(random_state)
+    B = random_state.random_sample((n, m))
+    A = np.empty((n+m, n+m))
+    A[:n, :n] = 0
+    A[n:, n:] = 0
+    A[:n, n:] = B
+    A[n:, :n] = -B.T
+    return NormalFormGame([Player(A) for i in range(2)])
 
 
 class TestSupportEnumeration():
@@ -38,6 +60,13 @@ class TestSupportEnumeration():
             for actions_computed, actions in zip(NEs_computed, d['NEs']):
                 for action_computed, action in zip(actions_computed, actions):
                     assert_allclose(action_computed, action)
+
+    def test_no_error_skew_sym(self):
+        # Test no LinAlgError is raised.
+        n, m = 3, 2
+        seed = 7028
+        g = random_skew_sym(n, m, random_state=seed)
+        NEs = support_enumeration(g)
 
 
 if __name__ == '__main__':

--- a/quantecon/util/numba.py
+++ b/quantecon/util/numba.py
@@ -1,0 +1,71 @@
+"""
+Utilities to support Numba jitted functions
+
+"""
+import numpy as np
+from numba import generated_jit, types
+from numba.targets.linalg import _LAPACK
+
+
+# BLAS kinds as letters
+_blas_kinds = {
+    types.float32: 's',
+    types.float64: 'd',
+    types.complex64: 'c',
+    types.complex128: 'z',
+}
+
+
+@generated_jit(nopython=True, cache=True)
+def _numba_linalg_solve(a, b):
+    """
+    Solve the linear equation ax = b directly calling a Numba internal
+    function. The data in `a` and `b` are interpreted in Fortran order,
+    and dtype of `a` and `b` must be the same, one of {float32, float64,
+    complex64, complex128}. `a` and `b` are modified in place, and the
+    solution is stored in `b`. *No error check is made for the inputs.*
+
+    Parameters
+    ----------
+    a : ndarray(ndim=2)
+        2-dimensional ndarray of shape (n, n).
+
+    b : ndarray(ndim=1 or 2)
+        1-dimensional ndarray of shape (n,) or 2-dimensional ndarray of
+        shape (n, nrhs).
+
+    Returns
+    -------
+    r : scalar(int)
+        r = 0 if successful.
+
+    Notes
+    -----
+    From github.com/numba/numba/blob/master/numba/targets/linalg.py
+
+    """
+    numba_xgesv = _LAPACK().numba_xgesv(a.dtype)
+    kind = ord(_blas_kinds[a.dtype])
+
+    def _numba_linalg_solve_impl(a, b):  # pragma: no cover
+        n = a.shape[-1]
+        if b.ndim == 1:
+            nrhs = 1
+        else:  # b.ndim == 2
+            nrhs = b.shape[-1]
+        F_INT_nptype = np.int32
+        ipiv = np.empty(n, dtype=F_INT_nptype)
+
+        r = numba_xgesv(
+            kind,         # kind
+            n,            # n
+            nrhs,         # nhrs
+            a.ctypes,     # a
+            n,            # lda
+            ipiv.ctypes,  # ipiv
+            b.ctypes,     # b
+            n             # ldb
+        )
+        return r
+
+    return _numba_linalg_solve_impl

--- a/quantecon/util/tests/test_numba.py
+++ b/quantecon/util/tests/test_numba.py
@@ -1,0 +1,59 @@
+"""
+Tests for Numba support utilities
+
+"""
+import numpy as np
+from numpy.testing import assert_array_equal
+from numba import jit
+from nose.tools import eq_, ok_
+from quantecon.util.numba import _numba_linalg_solve
+
+
+@jit(nopython=True)
+def numba_linalg_solve_orig(a, b):
+    return np.linalg.solve(a, b)
+
+
+class TestNumbaLinalgSolve:
+    def setUp(self):
+        self.dtypes = [np.float32, np.float64]
+        self.a = np.array([[3, 2, 0], [1, -1, 0], [0, 5, 1]])
+        self.b_1dim = np.array([2, 4, -1])
+        self.b_2dim = np.array([[2, 3], [4, 1], [-1, 0]])
+        self.a_singular = np.array([[0, 1, 2], [3, 4, 5], [3, 5, 7]])
+
+    def test_b_1dim(self):
+        for dtype in self.dtypes:
+            a = np.asfortranarray(self.a, dtype=dtype)
+            b = np.asfortranarray(self.b_1dim, dtype=dtype)
+            sol_orig = numba_linalg_solve_orig(a, b)
+            r = _numba_linalg_solve(a, b)
+            eq_(r, 0)
+            assert_array_equal(b, sol_orig)
+
+    def test_b_2dim(self):
+        for dtype in self.dtypes:
+            a = np.asfortranarray(self.a, dtype=dtype)
+            b = np.asfortranarray(self.b_2dim, dtype=dtype)
+            sol_orig = numba_linalg_solve_orig(a, b)
+            r = _numba_linalg_solve(a, b)
+            eq_(r, 0)
+            assert_array_equal(b, sol_orig)
+
+    def test_singular_a(self):
+        for b in [self.b_1dim, self.b_2dim]:
+            for dtype in self.dtypes:
+                a = np.asfortranarray(self.a_singular, dtype=dtype)
+                b = np.asfortranarray(b, dtype=dtype)
+                r = _numba_linalg_solve(a, b)
+                ok_(r != 0)
+
+
+if __name__ == '__main__':
+    import sys
+    import nose
+
+    argv = sys.argv[:]
+    argv.append('--verbose')
+    argv.append('--nocapture')
+    nose.main(argv=argv, defaultTest=__file__)


### PR DESCRIPTION
* It turned out that the workaround in item 3 in https://github.com/QuantEcon/QuantEcon.py/pull/263#issue-178525924 did not work properly in all cases.
* This fix replaces "SVD + linalg.solve" with `_numba_linalg_solve`, which calls directly Numba internal `numba_xgesv`.
* As a bonus, this leads to about 9x speedup.

```py
ns = [8, 9, 10, 11]
seed = 1234
for n in ns:
    g = gt.random_game((n, n), random_state=seed)
    %timeit gt.support_enumeration(g)
```

* Current version:
  * n = 8: `99.1 ms`
  * n = 9: `391 ms`
  * n = 10: `1.58 s`
  * n = 11: `6.56 s`

* This PR:
  * n = 8: `11.6 ms`
  * n = 9: `43 ms`
  * n = 10: `179 ms`
  * n = 11: `727 ms`

```py
numba.__version__
'0.30.1'
```