### PR TITLE
Fix class style

### DIFF
--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 from scipy.signal import dimpulse, freqz, dlsim
 
 
-class ARMA(object):
+class ARMA:
     r"""
     This class represents scalar ARMA(p, q) processes.
 

--- a/quantecon/discrete_rv.py
+++ b/quantecon/discrete_rv.py
@@ -13,7 +13,7 @@ from numpy import cumsum
 from numpy.random import uniform
 
 
-class DiscreteRV(object):
+class DiscreteRV:
     """
     Generates an array of draws from a discrete random variable with
     vector of probabilities given by q.

--- a/quantecon/distributions.py
+++ b/quantecon/distributions.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy.special import binom, beta
 
 
-class BetaBinomial(object):
+class BetaBinomial:
     """
     The Beta-Binomial distribution
 

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -11,7 +11,7 @@ of observations.
 import numpy as np
 
 
-class ECDF(object):
+class ECDF:
     """
     One-dimensional empirical distribution function given a vector of
     observations.

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -135,7 +135,7 @@ from numba import jit
 from ..util import check_random_state
 
 
-class Player(object):
+class Player:
     """
     Class representing a player in an N-player normal form game.
 
@@ -381,7 +381,7 @@ class Player(object):
             return idx
 
 
-class NormalFormGame(object):
+class NormalFormGame:
     """
     Class representing an N-player normal form game.
 

--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -22,7 +22,7 @@ def annotate_nodes(func):
     return new_func
 
 
-class DiGraph(object):
+class DiGraph:
     r"""
     Class for a directed graph. It stores useful information about the
     graph structure such as strong connectivity [1]_ and periodicity

--- a/quantecon/kalman.py
+++ b/quantecon/kalman.py
@@ -13,7 +13,7 @@ from quantecon.lss import LinearStateSpace
 from quantecon.matrix_eqn import solve_discrete_riccati
 
 
-class Kalman(object):
+class Kalman:
     r"""
     Implements the Kalman filter for the Gaussian state space model
 

--- a/quantecon/lae.py
+++ b/quantecon/lae.py
@@ -23,7 +23,7 @@ from textwrap import dedent
 import numpy as np
 
 
-class LAE(object):
+class LAE:
     """
     An instance is a representation of a look ahead estimator associated
     with a given stochastic kernel p and a vector of observations X.

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -14,7 +14,7 @@ from scipy.linalg import solve
 from .matrix_eqn import solve_discrete_riccati
 
 
-class LQ(object):
+class LQ:
     r"""
     This class is for analyzing linear quadratic optimal control
     problems of either the infinite horizon form

--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -60,7 +60,7 @@ def simulate_linear_model(A, x0, v, ts_length):
     return x
 
 
-class LinearStateSpace(object):
+class LinearStateSpace:
     r"""
     A class that describes a Gaussian linear state space model of the
     form:

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -96,7 +96,7 @@ from ..graph_tools import DiGraph
 from ..util import searchsorted, check_random_state
 
 
-class MarkovChain(object):
+class MarkovChain:
     """
     Class for a finite-state discrete-time Markov chain. It stores
     useful information such as the stationary distributions, and

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -117,7 +117,7 @@ from numba import jit
 from .core import MarkovChain
 
 
-class DiscreteDP(object):
+class DiscreteDP:
     r"""
     Class for dealing with a discrete dynamic program.
 

--- a/quantecon/robustlq.py
+++ b/quantecon/robustlq.py
@@ -16,7 +16,7 @@ from scipy.linalg import solve, inv, det
 from .matrix_eqn import solve_discrete_lyapunov
 
 
-class RBLQ(object):
+class RBLQ:
     r"""
     Provides methods for analysing infinite horizon robust LQ control
     problems of the form


### PR DESCRIPTION
This PR changes the class style (issue: jstac/QuantEcon.lectures#497).

Specifically, the PR changes `class Foo(object):` to `class Foo:`.

Note: `object` used to be required to provide some class infrastructure like `super` and `@property` in `python2.7` which is no longer required in `python3.X` as inheritance of these things are now implicit.