### PR TITLE
Test lemke howson exceptions

### DIFF
--- a/quantecon/game_theory/lemke_howson.py
+++ b/quantecon/game_theory/lemke_howson.py
@@ -5,6 +5,7 @@ Compute mixed Nash equilibria of a 2-player normal form game by the
 Lemke-Howson algorithm.
 
 """
+import numbers
 import numpy as np
 from numba import jit
 from .utilities import NashResult
@@ -128,11 +129,14 @@ def lemke_howson(g, init_pivot=0, max_iter=10**6, capping=None,
     nums_actions = g.nums_actions
     total_num = sum(nums_actions)
 
+    msg = '`init_pivot` must be an integer k' + \
+          'such that 0 <= k < {0}'.format(total_num)
+
+    if not isinstance(init_pivot, numbers.Integral):
+        raise TypeError(msg)
+
     if not (0 <= init_pivot < total_num):
-        raise ValueError(
-            '`init_pivot` must be an integer k such that 0 <= k < {0}'
-            .format(total_num)
-        )
+        raise ValueError(msg)
 
     if capping is None:
         capping = max_iter

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -6,7 +6,7 @@ Tests for lemke_howson.py
 """
 import numpy as np
 from numpy.testing import assert_allclose
-from nose.tools import eq_
+from nose.tools import eq_, raises
 from quantecon.game_theory import Player, NormalFormGame, lemke_howson
 
 
@@ -108,6 +108,32 @@ def test_lemke_howson_capping():
                            capping=1, full_output=True)
     eq_(res.num_iter, max_iter)
     eq_(res.init, init_pivot-1)
+
+
+@raises(TypeError)
+def test_lemke_howson_invalid_g():
+    bimatrix = [[(3, 3), (3, 2)],
+                [(2, 2), (5, 6)],
+                [(0, 3), (6, 1)]]
+    lemke_howson(bimatrix)
+
+
+@raises(ValueError)
+def test_lemke_howson_invalid_init_pivot_integer():
+    bimatrix = [[(3, 3), (3, 2)],
+                [(2, 2), (5, 6)],
+                [(0, 3), (6, 1)]]
+    g = NormalFormGame(bimatrix)
+    lemke_howson(g, -1)
+
+
+@raises(TypeError)
+def test_lemke_howson_invalid_init_pivot_float():
+    bimatrix = [[(3, 3), (3, 2)],
+                [(2, 2), (5, 6)],
+                [(0, 3), (6, 1)]]
+    g = NormalFormGame(bimatrix)
+    lemke_howson(g, 1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added tests for exceptions to lemke_howson.py and raise type error when init_pivot type is not an integer instance.

Fix #302 