### PR TITLE
FIX: Use relative tolerance in test_tic_tac_toc

### DIFF
--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -3,6 +3,8 @@ Filename: timing.py
 Authors: Pablo Winant
 Tests for timing.py
 """
+from numpy.testing import assert_allclose
+
 
 def test_tic_tac_toc():
 
@@ -22,9 +24,9 @@ def test_tic_tac_toc():
     time.sleep(h)
     el3 = toc()
 
-    assert(abs(el1-h)<0.01)
-    assert(abs(el2-h)<0.01)
-    assert(abs(el3-h*3)<0.01)
+    rtol = 0.1
+    for actual, desired in zip([el1, el2, el3], [h, h, h*3]):
+        assert_allclose(actual, desired, rtol=rtol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`test_tic_tac_toc` sometimes fails on my machine. Change absolute tolerance to relative tolerance.