### PR TITLE
RBLQ: add pure forecasting case 

### DIFF
--- a/quantecon/robustlq.py
+++ b/quantecon/robustlq.py
@@ -75,10 +75,7 @@ class RBLQ:
         # == Remaining parameters == #
         self.beta, self.theta = beta, theta
         # == Check for case of no control (pure forecasting problem) == #
-        if not Q.any() and not B.any():
-            self.pure_forecasting = True
-        else:
-            self.pure_forecasting = False
+        self.pure_forecasting = True if not Q.any() and not B.any() else False
 
     def __repr__(self):
         return self.__str__()
@@ -191,6 +188,7 @@ class RBLQ:
         # == Set up LQ version == #
         I = identity(j)
         Z = np.zeros((k, j))
+
         if self.pure_forecasting:
             lq = LQ(-beta*I*theta, R, A, C, beta=beta)
 

--- a/quantecon/robustlq.py
+++ b/quantecon/robustlq.py
@@ -151,7 +151,7 @@ class RBLQ:
         S1 = Q + beta * dot(B.T, dot(P, B))
         S2 = beta * dot(B.T, dot(P, A))
         S3 = beta * dot(A.T, dot(P, A))
-        F = solve(S1, S2) if not self.pure_forecasting else np.zeros((1, self.n))
+        F = solve(S1, S2) if not self.pure_forecasting else np.zeros((self.k, self.n))
         new_P = R - dot(S2.T, F) + S3
 
         return F, new_P
@@ -194,7 +194,7 @@ class RBLQ:
 
             # == Solve and convert back to robust problem == #
             P, f, d = lq.stationary_values()
-            F = np.zeros((1, self.n))
+            F = np.zeros((self.k, self.n))
             K = -f[:k, :]
 
         else:

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -1,5 +1,5 @@
 """
-Author: Chase Coleman
+Author: Chase Coleman and Balint Szoke
 Filename: test_robustlq
 
 Tests for robustlq.py file

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -1,8 +1,8 @@
 """
 Author: Chase Coleman
-Filename: test_lqcontrol
+Filename: test_robustlq
 
-Tests for lqcontrol.py file
+Tests for robustlq.py file
 
 """
 import sys
@@ -35,6 +35,7 @@ class TestRBLQControl(unittest.TestCase):
 
         R = -R
         Q = gamma / 2
+        Q_pf = 0.
 
         A = np.array([[1., 0., 0.],
                       [0., 1., 0.],
@@ -42,28 +43,45 @@ class TestRBLQControl(unittest.TestCase):
         B = np.array([[0.],
                       [1.],
                       [0.]])
+        B_pf = np.zeros((3, 1))
+
         C = np.array([[0.],
                       [0.],
                       [sigma_d]])
 
-
+        # the *_pf endings refer to an example with pure forecasting
+        # (see p171 in Robustness)
         self.rblq_test = RBLQ(Q, R, A, B, C, beta, theta)
+        self.rblq_test_pf = RBLQ(Q_pf, R, A, B_pf, C, beta, theta)
         self.lq_test = LQ(Q, R, A, B, C, beta)
 
         self.Fr, self.Kr, self.Pr = self.rblq_test.robust_rule()
+        self.Fr_pf, self.Kr_pf, self.Pr_pf = self.rblq_test_pf.robust_rule()
 
     def tearDown(self):
         del self.rblq_test
+        del self.rblq_test_pf
+
+    def test_pure_forecasting(self):
+        self.assertTrue(self.rblq_test_pf.pure_forecasting)
 
     def test_robust_rule_vs_simple(self):
         rblq = self.rblq_test
+        rblq_pf = self.rblq_test_pf
         Fr, Kr, Pr = self.Fr, self.Kr, self.Pr
+        Fr_pf, Kr_pf, Pr_pf = self.Fr_pf, self.Kr_pf, self.Pr_pf
 
         Fs, Ks, Ps = rblq.robust_rule_simple(P_init=Pr, tol=1e-12)
+        Fs_pf, Ks_pf, Ps_pf = rblq_pf.robust_rule_simple(P_init=Pr_pf, tol=1e-12)
 
         assert_allclose(Fr, Fs, rtol=1e-4)
         assert_allclose(Kr, Ks, rtol=1e-4)
         assert_allclose(Pr, Ps, rtol=1e-4)
+
+        assert_allclose(Fr_pf, Fs_pf, rtol=1e-4)
+        assert_allclose(Kr_pf, Ks_pf, rtol=1e-4)
+        assert_allclose(Pr_pf, Ps_pf, rtol=1e-4)
+
 
     def test_f2k_and_k2f(self):
         rblq = self.rblq_test


### PR DESCRIPTION
Adds the following case:
If Q and B are zero matrices, RBLQ assumes that the user wants to solve a "pure forecasting problem" defined on p171 in Robustness (Hansen and Sargent, 2008).

It is assumed that the user sets up the problem in a way that "eliminates" F.  This involves redefining the R and A matrices in equations (1) and (2) (of [this lecture](https://lectures.quantecon.org/py/robustness.html)) as 
R_adj = R + F'QF 
A_adj = A - BF
Then, using R_adj, A_adj, C with Q=B=0 (zero matrices), RBLQ returns a K which is the worst-case with respect to the proposed policy F.