### PR TITLE
WIP: Update Kalman Interface to accept setup matrices directly (in addition to LSS)

### DIFF
--- a/quantecon/kalman.py
+++ b/quantecon/kalman.py
@@ -61,11 +61,30 @@ class Kalman:
 
     """
 
-    def __init__(self, ss, x_hat=None, Sigma=None):
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+        if type(args[0]) is LinearStateSpace:
+            self._init_lss(*args, **kwargs)
+        else:
+            self._init_matrix(*args, **kwargs)
+
+    def _init_lss(self, ss, x_hat=None, Sigma=None):
+        """ setup object using a LinearStateSpace as the first argument
+        """
         self.ss = ss
         self.set_state(x_hat, Sigma)
         self.K_infinity = None
         self.Sigma_infinity = None
+
+    def _init_matrix(self, *args, **kwargs):
+        """ setup object by passing A, C, and G matrices directly
+        """
+        kwargs = dict(**kwargs)
+        lss_kwarg_keys = ['H','mu_0','Sigma_0']
+        lss_kwargs = { key : kwargs[key] for key in lss_kwarg_keys if key in kwargs.keys() }
+        lss = LinearStateSpace(*args, **lss_kwargs)
+        kalman_kwargs = { key : value for key, value in kwargs.items() if key not in lss_kwargs}
+        self._init_lss(lss, **kalman_kwargs)
 
     def set_state(self, x_hat, Sigma):
         if Sigma is None:


### PR DESCRIPTION
a proof of concept trial for accepting multiple interfaces for Kalman object, 

**Note:** no updated docstrings yet. Setting up in Branch for collaboration. 

This would allow `kalman` to accept the lecture example:

```python
# == parameters == #
theta = 10  # Constant value of state x_t
A, C, G, H = 1, 0, 1, 1
ss = LinearStateSpace(A, C, G, H, mu_0=theta)

# == set prior, initialize kalman filter == #
x_hat_0, Sigma_0 = 8, 1
kalman = Kalman(ss, x_hat_0, Sigma_0)
```
in addition to

```python
# == parameters == #
theta = 10  # Constant value of state x_t
A, C, G, H = 1, 0, 1, 1
x_hat_0, Sigma_0 = 8, 1
kalman = Kalman(A, C, G, H, mu_0=theta, x_hat_0, Sigma_0)
```

the key assumption is to check if the first element of the arguments list is an ``LSS`` object then it init's the object class (as per previously implemented) otherwise it constructs an ``LSS`` object internally with the matrices and then set's up using an ``LSS`` object.

@natashawatkins is this what you had in mind for #354? I think you were suggesting to replace the acceptance of ``LSS`` altogether but the benefit here is that old code won't break and Kalman will continue to work with those packaging up A, C, and G in an ``LSS`` object.

The downside to this approach is it makes the introspected interface to `Kalman` harder to read due to accepting arbitrary arguments and keyword arguments to parse for various init methods. 

The **key assumption** here is that the argument list is checked and if the first element of the passed argument list is type ``LinearStateSpace`` then ``_init_lss`` is used to populate the object otherise it is assumed that a user has passed ``A, C, and G`` matrices.