### PR TITLE
add ability to use setuptools in preference to distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-from distutils.core import setup
+# Use setuptools in preference to distutils
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import os
 
 #-Write Versions File-#


### PR DESCRIPTION
One nice feature is ability to use ``python setup.py develop``. 
This sets up a link between ``cwd`` and ``site-packages`` for ``install`` and enables quick testing etc.