### PR TITLE
FIX: Update `num_compositions`

### DIFF
--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -280,5 +280,5 @@ def num_compositions(m, n):
         Total number of m-part compositions of n.
 
     """
-    # docs.scipy.org/doc/scipy/reference/generated/scipy.misc.comb.html
+    # docs.scipy.org/doc/scipy/reference/generated/scipy.special.comb.html
     return scipy.special.comb(n+m-1, m-1, exact=True)

--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -9,7 +9,7 @@ determines the index of a point in the simplex.
 
 """
 import numpy as np
-import scipy.misc
+import scipy.special
 from numba import jit, njit
 
 
@@ -281,4 +281,4 @@ def num_compositions(m, n):
 
     """
     # docs.scipy.org/doc/scipy/reference/generated/scipy.misc.comb.html
-    return scipy.misc.comb(n+m-1, m-1, exact=True)
+    return scipy.special.comb(n+m-1, m-1, exact=True)


### PR DESCRIPTION
Use `scipy.special.comb` instead of `scipy.misc.comb` as `scipy.misc.comb` is deprecated in scipy 1.0.0.