### PR TITLE
Add Numba jit version of scipy.special.comb

### DIFF
--- a/quantecon/tests/test_gridtools.py
+++ b/quantecon/tests/test_gridtools.py
@@ -7,12 +7,12 @@ Tests for gridtools.py file
 """
 import numpy as np
 from numpy.testing import assert_array_equal
-from nose.tools import eq_
+from nose.tools import eq_, raises
 from nose.plugins.attrib import attr
 
 from quantecon.gridtools import (
     cartesian, mlinspace, _repeat_1d, simplex_grid, simplex_index,
-    num_compositions
+    num_compositions, num_compositions_jit
 )
 
 
@@ -211,6 +211,17 @@ class TestSimplexGrid:
     def test_num_compositions(self):
         num = num_compositions(3, 4)
         eq_(num, len(self.simplex_grid_3_4))
+
+    def test_num_compositions_jit(self):
+        num = num_compositions_jit(3, 4)
+        eq_(num, len(self.simplex_grid_3_4))
+
+        eq_(num_compositions_jit(100, 50), 0)  # Exceed max value of np.intp
+
+
+@raises(ValueError)
+def test_simplex_grid_raises_value_error_overflow():
+    simplex_grid(100, 50)  # Exceed max value of np.intp
 
 
 if __name__ == '__main__':

--- a/quantecon/util/numba.py
+++ b/quantecon/util/numba.py
@@ -3,7 +3,7 @@ Utilities to support Numba jitted functions
 
 """
 import numpy as np
-from numba import generated_jit, types
+from numba import jit, generated_jit, types
 from numba.targets.linalg import _LAPACK
 
 
@@ -69,3 +69,49 @@ def _numba_linalg_solve(a, b):
         return r
 
     return _numba_linalg_solve_impl
+
+
+@jit(types.intp(types.intp, types.intp), nopython=True, cache=True)
+def comb_jit(N, k):
+    """
+    Numba jitted function that computes N choose k. Return `0` if the
+    outcome exceeds the maximum value of `np.intp` or if N < 0, k < 0,
+    or k > N.
+
+    Parameters
+    ----------
+    N : scalar(int)
+
+    k : scalar(int)
+
+    Returns
+    -------
+    val : scalar(int)
+
+    """
+    # From scipy.special._comb_int_long
+    # github.com/scipy/scipy/blob/v1.0.0/scipy/special/_comb.pyx
+    INTP_MAX = np.iinfo(np.intp).max
+    if N < 0 or k < 0 or k > N:
+        return 0
+    if k == 0:
+        return 1
+    if k == 1:
+        return N
+    if N == INTP_MAX:
+        return 0
+
+    M = N + 1
+    nterms = min(k, N - k)
+
+    val = 1
+
+    for j in range(1, nterms + 1):
+        # Overflow check
+        if val > INTP_MAX // (M - j):
+            return 0
+
+        val *= M - j
+        val //= j
+
+    return val

--- a/quantecon/util/tests/test_numba.py
+++ b/quantecon/util/tests/test_numba.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from numba import jit
 from nose.tools import eq_, ok_
-from quantecon.util.numba import _numba_linalg_solve
+from quantecon.util.numba import _numba_linalg_solve, comb_jit
 
 
 @jit(nopython=True)
@@ -47,6 +47,30 @@ class TestNumbaLinalgSolve:
                 b = np.asfortranarray(b, dtype=dtype)
                 r = _numba_linalg_solve(a, b)
                 ok_(r != 0)
+
+
+class TestCombJit:
+    def setUp(self):
+        self.MAX_INTP = np.iinfo(np.intp).max
+
+    def test_comb(self):
+        N, k = 10, 3
+        N_choose_k = 120
+        eq_(comb_jit(N, k), N_choose_k)
+
+    def test_comb_zeros(self):
+        eq_(comb_jit(2, 3), 0)
+        eq_(comb_jit(-1, 3), 0)
+        eq_(comb_jit(2, -1), 0)
+
+        eq_(comb_jit(self.MAX_INTP, 2), 0)
+
+        N = np.int(self.MAX_INTP**0.5 * 2**0.5) + 1
+        eq_(comb_jit(N, 2), 0)
+
+    def test_max_intp(self):
+        eq_(comb_jit(self.MAX_INTP, 0), 1)
+        eq_(comb_jit(self.MAX_INTP, 1), self.MAX_INTP)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Add `comb_jit`, Numba jit version of `scipy.special.comb`
   Returns `0` if the outcome exceeds the maximum value of `np.intp`
2. Add `num_compositions_jit` which uses `comb_jit`
3. Compile `simplex_grid` in nopython mode using `num_compositions_jit`