### PR TITLE
remove models subpackage from QuantEcon.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-coverage --cover-package=quantecon --exclude=models 	#quantecon.models excluded from tests to prevent triggering the ImportWarning
+  - nosetests --with-coverage --cover-package=quantecon
 
 after_success:
   - coveralls

--- a/docs/qe_apidoc.py
+++ b/docs/qe_apidoc.py
@@ -26,9 +26,13 @@ $ python qe_apidoc.py single  # generates the single directory
 
 Notes
 -----
-This file can also be run from within ipython using the %%run magic.
+1. This file can also be run from within ipython using the %%run magic.
 To do this, use one of the commands above and replace `python` with
 `%%run`
+
+2. Models has been removed. But leaving infrastructure here for qe_apidoc
+in the event we need it in the future
+
 
 """
 import os

--- a/quantecon/models/__init__.py
+++ b/quantecon/models/__init__.py
@@ -1,1 +1,0 @@
-raise ImportError("The code previously contained in the quantecon.models subpackage has been migrated to the QuantEcon.applications (https://github.com/QuantEcon/QuantEcon.applications) repo")

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,6 @@ setup(name='quantecon',
                 'quantecon.random',
                 'quantecon.tests',
                 'quantecon.util',
-                #-Deprecated-#
-                'quantecon.models',
                 ],
       version=VERSION,
       description=DESCRIPTION,


### PR DESCRIPTION
the ``models`` subpackage was removed in ``0.3`` and a deprecation warning added. This  PR now completely removes the ``models`` subpackage as ``QuantEcon.applications`` no longer exists, and is not supported. 

I have left the ``models`` infrastructure in ``qe_apidoc.py`` in case it is required in the future. It was a way of organising the docs into ``tools`` and ``models`` headings.

``travis.yml`` has been updated to remove the ignore on models.
  