### PR TITLE
MAINT: Use `np.ix_` to extract submatrix

### DIFF
--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -351,7 +351,7 @@ class DiGraph:
             A DiGraph representing the subgraph.
 
         """
-        adj_matrix = self.csgraph[nodes, :][:, nodes]
+        adj_matrix = self.csgraph[np.ix_(nodes, nodes)]
 
         weighted = True  # To copy the dtype
 

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -408,13 +408,11 @@ class MarkovChain:
             rec_classes = self.recurrent_classes_indices
             stationary_dists = np.zeros((len(rec_classes), self.n))
             for i, rec_class in enumerate(rec_classes):
-                if not self.is_sparse:  # Dense
-                    stationary_dists[i, rec_class] = \
-                        gth_solve(self.P[rec_class, :][:, rec_class])
-                else:  # Sparse
-                    stationary_dists[i, rec_class] = \
-                        gth_solve(self.P[rec_class, :][:, rec_class].toarray(),
-                                  overwrite=True)
+                P_rec_class = self.P[np.ix_(rec_class, rec_class)]
+                if self.is_sparse:
+                    P_rec_class = P_rec_class.toarray()
+                stationary_dists[i, rec_class] = \
+                    gth_solve(P_rec_class, overwrite=True)
 
         self._stationary_dists = stationary_dists
 


### PR DESCRIPTION
Replace `matrix[indices, :][:, indices]` with `matrix[np.ix_(indices, indices)]`.

I happened to find [this fact](https://stackoverflow.com/questions/4257394/slicing-of-a-numpy-2d-array-or-how-do-i-extract-an-mxm-submatrix-from-an-nxn-ar#comment4623697_4257708).