### PR TITLE
RFC: Remove authors' name

### DIFF
--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -1,6 +1,4 @@
 """
-Filename: arma.py
-
 Provides functions for working with and visualizing scalar ARMA processes.
 
 TODO: 1. Fix warnings concerning casting complex variables back to floats

--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -1,6 +1,5 @@
 """
 Filename: arma.py
-Authors: Doc-Jin Jang, Jerry Choi, Thomas Sargent, John Stachurski
 
 Provides functions for working with and visualizing scalar ARMA processes.
 

--- a/quantecon/ce_util.py
+++ b/quantecon/ce_util.py
@@ -1,6 +1,5 @@
 """
 Filename: ce_util.py
-Authors: Chase Coleman, Spencer Lyon, John Stachurski, and Thomas Sargent
 Date: 2014-07-01
 
 Utility functions used in CompEcon

--- a/quantecon/ce_util.py
+++ b/quantecon/ce_util.py
@@ -1,7 +1,4 @@
 """
-Filename: ce_util.py
-Date: 2014-07-01
-
 Utility functions used in CompEcon
 
 Based routines found in the CompEcon toolbox by Miranda and Fackler.

--- a/quantecon/compute_fp.py
+++ b/quantecon/compute_fp.py
@@ -1,6 +1,5 @@
 """
 Filename: compute_fp.py
-Authors: Thomas Sargent, John Stachurski, Daisuke Oyama
 
 Compute an approximate fixed point of a given operator T, starting from
 specified initial condition v.

--- a/quantecon/compute_fp.py
+++ b/quantecon/compute_fp.py
@@ -1,6 +1,4 @@
 """
-Filename: compute_fp.py
-
 Compute an approximate fixed point of a given operator T, starting from
 specified initial condition v.
 

--- a/quantecon/discrete_rv.py
+++ b/quantecon/discrete_rv.py
@@ -1,8 +1,6 @@
 """
 Filename: discrete_rv.py
 
-Authors: Thomas Sargent, John Stachurski
-
 Generates an array of draws from a discrete random variable with a
 specified vector of probabilities.
 

--- a/quantecon/discrete_rv.py
+++ b/quantecon/discrete_rv.py
@@ -1,6 +1,4 @@
 """
-Filename: discrete_rv.py
-
 Generates an array of draws from a discrete random variable with a
 specified vector of probabilities.
 

--- a/quantecon/distributions.py
+++ b/quantecon/distributions.py
@@ -1,6 +1,4 @@
 """
-Filename: distributions.py
-
 Probability distributions useful in economics.
 
 References

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -1,6 +1,4 @@
 """
-Filename: ecdf.py
-
 Implements the empirical cumulative distribution function given an array
 of observations.
 

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -1,8 +1,6 @@
 """
 Filename: ecdf.py
 
-Authors: Thomas Sargent, John Stachurski
-
 Implements the empirical cumulative distribution function given an array
 of observations.
 

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -1,8 +1,6 @@
 """
 Filename: estspec.py
 
-Authors: Thomas Sargent, John Stachurski
-
 Functions for working with periodograms of scalar data.
 
 """

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -1,6 +1,4 @@
 """
-Filename: estspec.py
-
 Functions for working with periodograms of scalar data.
 
 """

--- a/quantecon/game_theory/lemke_howson.py
+++ b/quantecon/game_theory/lemke_howson.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Compute mixed Nash equilibria of a 2-player normal form game by the
 Lemke-Howson algorithm.
 

--- a/quantecon/game_theory/mclennan_tourky.py
+++ b/quantecon/game_theory/mclennan_tourky.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Compute mixed Nash equilibria of an N-player normal form game by
 applying the imitation game algorithm by McLennan and Tourky to the best
 response correspondence.

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -1,6 +1,4 @@
 r"""
-Authors: Tomohiro Kusano, Daisuke Oyama
-
 Tools for normal form games.
 
 Definitions and Basic Concepts

--- a/quantecon/game_theory/pure_nash.py
+++ b/quantecon/game_theory/pure_nash.py
@@ -1,6 +1,4 @@
 """
-Author: Zejin Shi
-
 Methods for computing pure Nash equilibria of a normal form game.
 (For now, only brute force method is supported)
 

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -1,6 +1,4 @@
 """
-Filename: random.py
-
 Generate random NormalFormGame instances.
 
 """

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -1,8 +1,6 @@
 """
 Filename: random.py
 
-Author: Daisuke Oyama
-
 Generate random NormalFormGame instances.
 
 """

--- a/quantecon/game_theory/support_enumeration.py
+++ b/quantecon/game_theory/support_enumeration.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Compute all mixed Nash equilibria of a 2-player (non-degenerate) normal
 form game by support enumeration.
 

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Tests for lemke_howson.py
 
 """

--- a/quantecon/game_theory/tests/test_mclennan_tourky.py
+++ b/quantecon/game_theory/tests/test_mclennan_tourky.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Tests for mclennan_tourky.py
 
 """

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Tests for normal_form_game.py
 
 """

--- a/quantecon/game_theory/tests/test_pure_nash.py
+++ b/quantecon/game_theory/tests/test_pure_nash.py
@@ -1,6 +1,4 @@
 """
-Author: Zejin Shi
-
 Tests for pure_nash.py
 
 """

--- a/quantecon/game_theory/tests/test_random.py
+++ b/quantecon/game_theory/tests/test_random.py
@@ -1,6 +1,4 @@
 """
-Filename: test_random.py
-
 Tests for game_theory/random.py
 
 """

--- a/quantecon/game_theory/tests/test_random.py
+++ b/quantecon/game_theory/tests/test_random.py
@@ -1,6 +1,5 @@
 """
 Filename: test_random.py
-Author: Daisuke Oyama
 
 Tests for game_theory/random.py
 

--- a/quantecon/game_theory/tests/test_support_enumeration.py
+++ b/quantecon/game_theory/tests/test_support_enumeration.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Tests for support_enumeration.py
 
 """

--- a/quantecon/game_theory/tests/test_vertex_enumeration.py
+++ b/quantecon/game_theory/tests/test_vertex_enumeration.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Tests for vertex_enumeration.py
 
 """

--- a/quantecon/game_theory/vertex_enumeration.py
+++ b/quantecon/game_theory/vertex_enumeration.py
@@ -1,6 +1,4 @@
 """
-Author: Daisuke Oyama
-
 Compute all mixed Nash equilibria of a 2-player normal form game by
 vertex enumeration.
 

--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -1,6 +1,4 @@
 """
-Filename: graph_tools.py
-
 Tools for dealing with a directed graph.
 
 """

--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -1,8 +1,6 @@
 """
 Filename: graph_tools.py
 
-Author: Daisuke Oyama
-
 Tools for dealing with a directed graph.
 
 """

--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -1,6 +1,4 @@
 """
-Filename: gridtools.py
-
 Implements cartesian products and regular cartesian grids, and provides
 a function that constructs a grid for a simplex as well as one that
 determines the index of a point in the simplex.

--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -1,8 +1,6 @@
 """
 Filename: gridtools.py
 
-Authors: Pablo Winant, Daisuke Oyama
-
 Implements cartesian products and regular cartesian grids, and provides
 a function that constructs a grid for a simplex as well as one that
 determines the index of a point in the simplex.

--- a/quantecon/ivp.py
+++ b/quantecon/ivp.py
@@ -13,8 +13,6 @@ between grid points. The `quantecon.ivp` module also provides a method
 for computing the residual of the solution which can be used for
 assessing the overall accuracy of the approximated solution.
 
-@date : 2014-09-09
-
 """
 from __future__ import division
 

--- a/quantecon/ivp.py
+++ b/quantecon/ivp.py
@@ -13,7 +13,6 @@ between grid points. The `quantecon.ivp` module also provides a method
 for computing the residual of the solution which can be used for
 assessing the overall accuracy of the approximated solution.
 
-@author : David R. Pugh
 @date : 2014-09-09
 
 """
@@ -24,7 +23,7 @@ from scipy import integrate, interpolate
 
 
 class IVP(integrate.ode):
-    
+
     r"""
     Creates an instance of the IVP class.
 

--- a/quantecon/kalman.py
+++ b/quantecon/kalman.py
@@ -1,8 +1,10 @@
 """
-Filename: kalman.py
-Reference: https://lectures.quantecon.org/py/kalman.html
-
 Implements the Kalman filter for a linear Gaussian state space model.
+
+References
+----------
+
+https://lectures.quantecon.org/py/kalman.html
 
 """
 from textwrap import dedent

--- a/quantecon/lae.py
+++ b/quantecon/lae.py
@@ -1,6 +1,4 @@
 r"""
-Filename: lae.py
-
 Computes a sequence of marginal densities for a continuous state space
 Markov chain :math:`X_t` where the transition probabilities can be represented
 as densities. The estimate of the marginal density of :math:`X_t` is

--- a/quantecon/lae.py
+++ b/quantecon/lae.py
@@ -1,8 +1,6 @@
 r"""
 Filename: lae.py
 
-Authors: Thomas J. Sargent, John Stachurski,
-
 Computes a sequence of marginal densities for a continuous state space
 Markov chain :math:`X_t` where the transition probabilities can be represented
 as densities. The estimate of the marginal density of :math:`X_t` is

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -1,6 +1,4 @@
 """
-Filename: lqcontrol.py
-
 Provides a class called LQ for solving linear quadratic control
 problems.
 

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -1,8 +1,6 @@
 """
 Filename: lqcontrol.py
 
-Authors: Thomas J. Sargent, John Stachurski
-
 Provides a class called LQ for solving linear quadratic control
 problems.
 

--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -1,8 +1,11 @@
 """
-Filename: lss.py
-Reference: https://lectures.quantecon.org/py/linear_models.html
-
 Computes quantities associated with the Gaussian linear state space model.
+
+References
+----------
+
+https://lectures.quantecon.org/py/linear_models.html
+
 """
 
 from textwrap import dedent

--- a/quantecon/markov/approximation.py
+++ b/quantecon/markov/approximation.py
@@ -1,8 +1,6 @@
 """
 Filename: approximation.py
 
-Authors: Thomas Sargent, John Stachurski
-
 tauchen
 -------
 Discretizes Gaussian linear AR(1) processes via Tauchen's method

--- a/quantecon/markov/approximation.py
+++ b/quantecon/markov/approximation.py
@@ -1,6 +1,4 @@
 """
-Filename: approximation.py
-
 tauchen
 -------
 Discretizes Gaussian linear AR(1) processes via Tauchen's method

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -1,7 +1,4 @@
 r"""
-Authors: Chase Coleman, Spencer Lyon, Daisuke Oyama, Tom Sargent,
-         John Stachurski
-
 Filename: core.py
 
 This file contains some useful objects for handling a finite-state

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -1,6 +1,4 @@
 r"""
-Filename: core.py
-
 This file contains some useful objects for handling a finite-state
 discrete-time Markov chain.
 

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -1,6 +1,4 @@
 r"""
-Filename: ddp.py
-
 Module for solving dynamic programs (also known as Markov decision
 processes) with finite states and actions.
 

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -1,8 +1,6 @@
 r"""
 Filename: ddp.py
 
-Author: Daisuke Oyama
-
 Module for solving dynamic programs (also known as Markov decision
 processes) with finite states and actions.
 

--- a/quantecon/markov/gth_solve.py
+++ b/quantecon/markov/gth_solve.py
@@ -1,8 +1,6 @@
 """
 Filename: gth_solve.py
 
-Author: Daisuke Oyama
-
 Routine to compute the stationary distribution of an irreducible Markov
 chain by the Grassmann-Taksar-Heyman (GTH) algorithm.
 

--- a/quantecon/markov/gth_solve.py
+++ b/quantecon/markov/gth_solve.py
@@ -1,6 +1,4 @@
 """
-Filename: gth_solve.py
-
 Routine to compute the stationary distribution of an irreducible Markov
 chain by the Grassmann-Taksar-Heyman (GTH) algorithm.
 

--- a/quantecon/markov/random.py
+++ b/quantecon/markov/random.py
@@ -1,8 +1,6 @@
 """
 Filename: random.py
 
-Author: Daisuke Oyama
-
 Generate MarkovChain and DiscreteDP instances randomly.
 
 """

--- a/quantecon/markov/random.py
+++ b/quantecon/markov/random.py
@@ -1,6 +1,4 @@
 """
-Filename: random.py
-
 Generate MarkovChain and DiscreteDP instances randomly.
 
 """

--- a/quantecon/markov/tests/test_approximation.py
+++ b/quantecon/markov/tests/test_approximation.py
@@ -1,7 +1,4 @@
 """
-Filename: test_approximation.py
-Date: 07/18/2014
-
 Tests for approximation.py file (i.e. tauchen)
 
 """

--- a/quantecon/markov/tests/test_approximation.py
+++ b/quantecon/markov/tests/test_approximation.py
@@ -1,6 +1,5 @@
 """
 Filename: test_approximation.py
-Authors: Chase Coleman
 Date: 07/18/2014
 
 Tests for approximation.py file (i.e. tauchen)
@@ -89,7 +88,7 @@ class TestRouwenhorst(unittest.TestCase):
     def test_control_case(self):
         n = 3; ybar = 1; sigma = 0.5; rho = 0.8;
         mc_rouwenhorst = rouwenhorst(n, ybar, sigma, rho)
-        mc_rouwenhorst.x, mc_rouwenhorst.P = mc_rouwenhorst.state_values, mc_rouwenhorst.P 
+        mc_rouwenhorst.x, mc_rouwenhorst.P = mc_rouwenhorst.state_values, mc_rouwenhorst.P
         sigma_y = np.sqrt(sigma**2 / (1-rho**2))
         psi = sigma_y * np.sqrt(n-1)
         known_x = np.array([-psi+5.0, 5., psi+5.0])

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -1,6 +1,4 @@
 """
-Filename: test_ddp.py
-
 Tests for markov/ddp.py
 
 """

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -1,6 +1,5 @@
 """
 Filename: test_ddp.py
-Author: Daisuke Oyama
 
 Tests for markov/ddp.py
 

--- a/quantecon/markov/tests/test_gth_solve.py
+++ b/quantecon/markov/tests/test_gth_solve.py
@@ -1,6 +1,5 @@
 """
 Filename: gth_solve.py
-Author: Daisuke Oyama
 
 Tests for gth_solve.py
 

--- a/quantecon/markov/tests/test_gth_solve.py
+++ b/quantecon/markov/tests/test_gth_solve.py
@@ -1,6 +1,4 @@
 """
-Filename: gth_solve.py
-
 Tests for gth_solve.py
 
 """

--- a/quantecon/markov/tests/test_random.py
+++ b/quantecon/markov/tests/test_random.py
@@ -1,6 +1,4 @@
 """
-Filename: test_random.py
-
 Tests for markov/random.py
 
 """

--- a/quantecon/markov/tests/test_random.py
+++ b/quantecon/markov/tests/test_random.py
@@ -1,6 +1,5 @@
 """
 Filename: test_random.py
-Author: Daisuke Oyama
 
 Tests for markov/random.py
 

--- a/quantecon/markov/tests/test_utilities.py
+++ b/quantecon/markov/tests/test_utilities.py
@@ -1,6 +1,4 @@
 """
-Filename: test_utilities.py
-
 Tests for markov/utilities.py
 
 """

--- a/quantecon/markov/tests/test_utilities.py
+++ b/quantecon/markov/tests/test_utilities.py
@@ -1,6 +1,5 @@
 """
 Filename: test_utilities.py
-Author: Daisuke Oyama
 
 Tests for markov/utilities.py
 

--- a/quantecon/matrix_eqn.py
+++ b/quantecon/matrix_eqn.py
@@ -1,6 +1,4 @@
 """
-Filename: matrix_eqn.py
-
 This file holds several functions that are used to solve matrix
 equations.  Currently has functionality to solve:
 

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -1,7 +1,4 @@
 """
-Filename: quad.py
-Date: 2014-07-01
-
 Defining various quadrature routines.
 
 Based on the quadrature routines found in the CompEcon toolbox by

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -1,6 +1,5 @@
 """
 Filename: quad.py
-Authors: Chase Coleman, Spencer Lyon
 Date: 2014-07-01
 
 Defining various quadrature routines.

--- a/quantecon/quadsums.py
+++ b/quantecon/quadsums.py
@@ -1,6 +1,4 @@
 """
-Filename: quadsums.py
-
 This module provides functions to compute quadratic sums of the form described
 in the docstrings.
 

--- a/quantecon/quadsums.py
+++ b/quantecon/quadsums.py
@@ -1,8 +1,6 @@
 """
 Filename: quadsums.py
 
-Authors: Thomas Sargent,  John Stachurski
-
 This module provides functions to compute quadratic sums of the form described
 in the docstrings.
 

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -1,5 +1,6 @@
 """
 Utilities to Support Random Operations and Generating Vectors and Matrices
+
 """
 
 import numpy as np

--- a/quantecon/robustlq.py
+++ b/quantecon/robustlq.py
@@ -1,6 +1,4 @@
 """
-Filename: robustlq.py
-
 Solves robust LQ control problems.
 
 """

--- a/quantecon/robustlq.py
+++ b/quantecon/robustlq.py
@@ -1,8 +1,6 @@
 """
 Filename: robustlq.py
 
-Authors: Chase Coleman, Spencer Lyon, Thomas Sargent, John Stachurski
-
 Solves robust LQ control problems.
 
 """

--- a/quantecon/tests/test_arma.py
+++ b/quantecon/tests/test_arma.py
@@ -1,7 +1,4 @@
 """
-Filename: test_arma.py
-Date: 07/24/2014
-
 Tests for arma.py file.  Most of this testing can be considered
 covered by the numpy tests since we rely on much of their code.
 

--- a/quantecon/tests/test_arma.py
+++ b/quantecon/tests/test_arma.py
@@ -1,6 +1,5 @@
 """
 Filename: test_arma.py
-Authors: Chase Coleman
 Date: 07/24/2014
 
 Tests for arma.py file.  Most of this testing can be considered

--- a/quantecon/tests/test_compute_fp.py
+++ b/quantecon/tests/test_compute_fp.py
@@ -1,7 +1,5 @@
 """
-tests for quantecon.compute_fp module
-
-@date : 2014-07-31
+Tests for compute_fp.py
 
 References
 ----------

--- a/quantecon/tests/test_compute_fp.py
+++ b/quantecon/tests/test_compute_fp.py
@@ -1,7 +1,6 @@
 """
 tests for quantecon.compute_fp module
 
-@author : Spencer Lyon
 @date : 2014-07-31
 
 References

--- a/quantecon/tests/test_discrete_rv.py
+++ b/quantecon/tests/test_discrete_rv.py
@@ -1,7 +1,5 @@
 """
-tests for quantecon.discrete_rv
-
-@date : 2014-07-31
+Tests for discrete_rv.py
 
 """
 from __future__ import division

--- a/quantecon/tests/test_discrete_rv.py
+++ b/quantecon/tests/test_discrete_rv.py
@@ -1,7 +1,6 @@
 """
 tests for quantecon.discrete_rv
 
-@author : Spencer Lyon
 @date : 2014-07-31
 
 """

--- a/quantecon/tests/test_distributions.py
+++ b/quantecon/tests/test_distributions.py
@@ -1,6 +1,5 @@
 """
 Filename: test_distributions.py
-Author: Quentin Batista
 
 Tests for distributions.py
 
@@ -18,7 +17,7 @@ class TestBetaBinomial:
         self.a = 5
         self.b = 5
         self.test_obj = BetaBinomial(self.n, self.a, self.b)
-    
+
     def test_init(self):
         eq_(self.test_obj.n, self.n)
         eq_(self.test_obj.a, self.a)
@@ -42,7 +41,7 @@ class TestBetaBinomial:
         b = 1
         test_obj = BetaBinomial(n, a, b)
         assert_allclose(test_obj.pdf(), np.full(n+1, 1/(n+1)))
-            
+
 
 if __name__ == '__main__':
     import sys

--- a/quantecon/tests/test_distributions.py
+++ b/quantecon/tests/test_distributions.py
@@ -1,6 +1,4 @@
 """
-Filename: test_distributions.py
-
 Tests for distributions.py
 
 """

--- a/quantecon/tests/test_ecdf.py
+++ b/quantecon/tests/test_ecdf.py
@@ -1,7 +1,5 @@
 """
-tests for quantecon.ecdf
-
-@date : 2014-07-31
+Tests for ecdf.py
 
 """
 from __future__ import division

--- a/quantecon/tests/test_ecdf.py
+++ b/quantecon/tests/test_ecdf.py
@@ -1,7 +1,6 @@
 """
 tests for quantecon.ecdf
 
-@author : Spencer Lyon
 @date : 2014-07-31
 
 """

--- a/quantecon/tests/test_estspec.py
+++ b/quantecon/tests/test_estspec.py
@@ -1,7 +1,5 @@
 """
-tests for quantecon.estspec
-
-@date : 2014-08-01
+Tests for estspec.py
 
 TODO: write tests that check accuracy of returns
 

--- a/quantecon/tests/test_estspec.py
+++ b/quantecon/tests/test_estspec.py
@@ -1,7 +1,6 @@
 """
 tests for quantecon.estspec
 
-@author : Spencer Lyon
 @date : 2014-08-01
 
 TODO: write tests that check accuracy of returns

--- a/quantecon/tests/test_graph_tools.py
+++ b/quantecon/tests/test_graph_tools.py
@@ -1,6 +1,4 @@
 """
-Filename: test_graph_tools.py
-
 Tests for graph_tools.py
 
 """

--- a/quantecon/tests/test_graph_tools.py
+++ b/quantecon/tests/test_graph_tools.py
@@ -1,6 +1,5 @@
 """
 Filename: test_graph_tools.py
-Author: Daisuke Oyama
 
 Tests for graph_tools.py
 

--- a/quantecon/tests/test_gridtools.py
+++ b/quantecon/tests/test_gridtools.py
@@ -1,5 +1,4 @@
 """
-Authors: Pablo Winant, Daisuke Oyama
 Filename: test_cartesian.py
 
 Tests for gridtools.py file

--- a/quantecon/tests/test_gridtools.py
+++ b/quantecon/tests/test_gridtools.py
@@ -1,6 +1,4 @@
 """
-Filename: test_cartesian.py
-
 Tests for gridtools.py file
 
 """

--- a/quantecon/tests/test_ivp.py
+++ b/quantecon/tests/test_ivp.py
@@ -1,7 +1,6 @@
 """
 Tests for ivp.py
 
-@author : David R. Pugh
 @date : 2014-09-09
 
 """

--- a/quantecon/tests/test_ivp.py
+++ b/quantecon/tests/test_ivp.py
@@ -1,8 +1,6 @@
 """
 Tests for ivp.py
 
-@date : 2014-09-09
-
 """
 import nose
 

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -1,7 +1,5 @@
 """
-Date: 08/04/2014
-
-Contains test for the kalman.py file.
+Tests for the kalman.py
 
 """
 import sys

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -1,5 +1,4 @@
 """
-Author: Chase Coleman
 Date: 08/04/2014
 
 Contains test for the kalman.py file.

--- a/quantecon/tests/test_lae.py
+++ b/quantecon/tests/test_lae.py
@@ -1,7 +1,6 @@
 """
 Tests for lae.py
 
-@author : Spencer Lyon
 @date : 2014-08-02
 
 TODO: write (economically) meaningful tests for this module

--- a/quantecon/tests/test_lae.py
+++ b/quantecon/tests/test_lae.py
@@ -1,8 +1,6 @@
 """
 Tests for lae.py
 
-@date : 2014-08-02
-
 TODO: write (economically) meaningful tests for this module
 
 """

--- a/quantecon/tests/test_lqcontrol.py
+++ b/quantecon/tests/test_lqcontrol.py
@@ -1,5 +1,4 @@
 """
-Author: Chase Coleman
 Filename: test_lqcontrol
 
 Tests for lqcontrol.py file

--- a/quantecon/tests/test_lqcontrol.py
+++ b/quantecon/tests/test_lqcontrol.py
@@ -1,6 +1,4 @@
 """
-Filename: test_lqcontrol
-
 Tests for lqcontrol.py file
 
 """

--- a/quantecon/tests/test_lqnash.py
+++ b/quantecon/tests/test_lqnash.py
@@ -1,6 +1,5 @@
 """
 Filename: test_lqnash.py
-Authors: Chase Coleman
 Date: 07/24/2014
 
 Tests for lqnash.py file.
@@ -91,7 +90,7 @@ class TestLQNash(unittest.TestCase):
         m2 = np.copy(m1)
 
         # build model and solve it
-        f1, f2, p1, p2 = nnash(a, b1, b2, r1, r2, q1, q2, s1, s2, w1, w2, m1, 
+        f1, f2, p1, p2 = nnash(a, b1, b2, r1, r2, q1, q2, s1, s2, w1, w2, m1,
                                m2)
 
         aaa = a - b1.dot(f1) - b2.dot(f2)

--- a/quantecon/tests/test_lqnash.py
+++ b/quantecon/tests/test_lqnash.py
@@ -1,8 +1,5 @@
 """
-Filename: test_lqnash.py
-Date: 07/24/2014
-
-Tests for lqnash.py file.
+Tests for lqnash.py
 
 """
 from __future__ import division

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -1,6 +1,5 @@
 """
 Filename: test_lss.py
-Authors: Chase Coleman
 Date: 07/24/2014
 
 Tests for lss.py file
@@ -50,7 +49,7 @@ class TestLinearStateSpace(unittest.TestCase):
         xval, yval = ss.simulate(ts_length=5, random_state=5)
         expected_output = np.array([0.75 , 0.73456137, 0.6812898, 0.76876387,
                                     .71772107])
- 
+
         assert_allclose(xval[0], expected_output)
         assert_allclose(yval[0], expected_output)
 
@@ -63,9 +62,9 @@ class TestLinearStateSpace(unittest.TestCase):
 
     def test_replicate_with_seed(self):
         xval, yval = self.ss.replicate(T=100, num_reps=5, random_state=5)
-        expected_output = np.array([0.06871204, 0.06937119, -0.1478022, 
+        expected_output = np.array([0.06871204, 0.06937119, -0.1478022,
                                     0.23841252, -0.06823762])
-        
+
         assert_allclose(xval[0], expected_output)
         assert_allclose(yval[0], expected_output)
 

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -1,8 +1,5 @@
 """
-Filename: test_lss.py
-Date: 07/24/2014
-
-Tests for lss.py file
+Tests for lss.py
 
 """
 import sys

--- a/quantecon/tests/test_lyapunov.py
+++ b/quantecon/tests/test_lyapunov.py
@@ -1,6 +1,5 @@
 """
 Filename: test_tauchen.py
-Authors: Chase Coleman, John Stachurski
 Date: 07/22/2014
 
 Tests for ricatti.py file

--- a/quantecon/tests/test_lyapunov.py
+++ b/quantecon/tests/test_lyapunov.py
@@ -1,8 +1,5 @@
 """
-Filename: test_tauchen.py
-Date: 07/22/2014
-
-Tests for ricatti.py file
+Tests for ricatti.py
 
 """
 import numpy as np

--- a/quantecon/tests/test_matrix_eqn.py
+++ b/quantecon/tests/test_matrix_eqn.py
@@ -1,5 +1,5 @@
 """
-tests for quantecon.util
+Tests for quantecon.util
 
 """
 from __future__ import division

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -1,8 +1,5 @@
 """
-Filename: test_quad.py
-Date: 2014-07-02
-
-Tests for quantecon.quad module
+Tests for quad.py
 
 Notes
 -----

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -1,6 +1,5 @@
 """
 Filename: test_quad.py
-Authors: Spencer Lyon
 Date: 2014-07-02
 
 Tests for quantecon.quad module

--- a/quantecon/tests/test_quadsum.py
+++ b/quantecon/tests/test_quadsum.py
@@ -1,8 +1,5 @@
 """
-Filename: test_tauchen.py
-Date: 07/24/2014
-
-Tests for quadsums.py file
+Tests for quadsums.py
 
 """
 import sys

--- a/quantecon/tests/test_quadsum.py
+++ b/quantecon/tests/test_quadsum.py
@@ -1,6 +1,5 @@
 """
 Filename: test_tauchen.py
-Authors: Chase Coleman
 Date: 07/24/2014
 
 Tests for quadsums.py file

--- a/quantecon/tests/test_rank_nullspace.py
+++ b/quantecon/tests/test_rank_nullspace.py
@@ -1,8 +1,5 @@
 """
-Filename: test_tauchen.py
-Date: 07/21/2014
-
-Tests for rank_nullspace.py file
+Tests for rank_nullspace.py
 
 """
 import sys

--- a/quantecon/tests/test_rank_nullspace.py
+++ b/quantecon/tests/test_rank_nullspace.py
@@ -1,6 +1,5 @@
 """
 Filename: test_tauchen.py
-Authors: Chase Coleman
 Date: 07/21/2014
 
 Tests for rank_nullspace.py file

--- a/quantecon/tests/test_ricatti.py
+++ b/quantecon/tests/test_ricatti.py
@@ -1,7 +1,4 @@
 """
-Filename: test_ricatti.py
-Date: 07/22/2014
-
 Tests for solve_discrete_riccati in matrix_eqn.py file
 
 """

--- a/quantecon/tests/test_ricatti.py
+++ b/quantecon/tests/test_ricatti.py
@@ -1,6 +1,5 @@
 """
 Filename: test_ricatti.py
-Authors: Chase Coleman, John Stachurski
 Date: 07/22/2014
 
 Tests for solve_discrete_riccati in matrix_eqn.py file

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -1,7 +1,5 @@
 """
-Filename: test_robustlq
-
-Tests for robustlq.py file
+Tests for robustlq.py
 
 """
 import sys

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -1,5 +1,4 @@
 """
-Author: Chase Coleman and Balint Szoke
 Filename: test_robustlq
 
 Tests for robustlq.py file

--- a/quantecon/tests/util.py
+++ b/quantecon/tests/util.py
@@ -1,8 +1,6 @@
 """
 Utilities for testing within quantecon
 
-@date : 2014-08-01 10:56:32
-
 """
 import sys
 import os

--- a/quantecon/tests/util.py
+++ b/quantecon/tests/util.py
@@ -1,7 +1,6 @@
 """
 Utilities for testing within quantecon
 
-@author : Spencer Lyon
 @date : 2014-08-01 10:56:32
 
 """

--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -1,6 +1,5 @@
 """
 Filename: timing.py
-Authors: Pablo Winant
 Tests for timing.py
 """
 

--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -1,6 +1,6 @@
 """
-Filename: timing.py
 Tests for timing.py
+
 """
 
 import time

--- a/quantecon/util/timing.py
+++ b/quantecon/util/timing.py
@@ -1,8 +1,6 @@
 """
 Filename: timing.py
 
-Authors: Pablo Winant
-
 Date: 10/16/14
 
 Provides Matlab-like tic, tac and toc functions.

--- a/quantecon/util/timing.py
+++ b/quantecon/util/timing.py
@@ -1,8 +1,4 @@
 """
-Filename: timing.py
-
-Date: 10/16/14
-
 Provides Matlab-like tic, tac and toc functions.
 
 """


### PR DESCRIPTION
Close #394 

The format of the description is not consistent across files. Here's my proposal to make it consistent:

```
"""
Filename: <filename>

<Description>

References (if applicable)
----------
 <References> 
"""
```