### PR TITLE
add minimum version number for numba support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,6 @@ setup(name='quantecon',
       author_email='john.stachurski@gmail.com',
       url='https://github.com/QuantEcon/QuantEcon.py',  # URL to the repo
       download_url='https://github.com/QuantEcon/QuantEcon.py/tarball/' + VERSION,
-      keywords=['quantitative', 'economics']
+      keywords=['quantitative', 'economics'],
       install_requires=['numba>=0.36.2']
       )

--- a/setup.py
+++ b/setup.py
@@ -112,4 +112,5 @@ setup(name='quantecon',
       url='https://github.com/QuantEcon/QuantEcon.py',  # URL to the repo
       download_url='https://github.com/QuantEcon/QuantEcon.py/tarball/' + VERSION,
       keywords=['quantitative', 'economics']
+      install_requires=['numba>=0.36.2']
       )

--- a/setup.py
+++ b/setup.py
@@ -112,5 +112,10 @@ setup(name='quantecon',
       url='https://github.com/QuantEcon/QuantEcon.py',  # URL to the repo
       download_url='https://github.com/QuantEcon/QuantEcon.py/tarball/' + VERSION,
       keywords=['quantitative', 'economics'],
-      install_requires=['numba>=0.36.2']
+      install_requires=[
+          'numba>=0.36.2',
+          'numpy',
+          'scipy',
+          'sympy',
+          ]
       )


### PR DESCRIPTION
This PR adds ``0.36.2`` as a minimum numba version required for installation in ``setup.py``

``numba`` is one of the key dependencies for QuantEcon.py. Given our user base -- it may be helpful to alternatively write a version check in the base ``__init__.py`` file which would give us the opportunity to issue a more useful error message based on ``conda``.

Could check if ``numba.__version__ > minimum value`` otherwise print out instructions to upgrade such as ``conda install numba=0.37``.  Any comments welcome.