### PR TITLE
EHN: Add `qhull_options` to `game_theory.vertex_enumeration`

### DIFF
--- a/quantecon/game_theory/tests/test_vertex_enumeration.py
+++ b/quantecon/game_theory/tests/test_vertex_enumeration.py
@@ -44,6 +44,25 @@ class TestVertexEnumeration:
                     assert_allclose(action_computed, action)
 
 
+def test_vertex_enumeration_qhull_options():
+    # Degenerate game, player 0's actions reordered
+    bimatrix = [[(0, 3), (6, 1)],
+                [(2, 2), (5, 6)],
+                [(3, 3), (3, 3)]]
+    g = NormalFormGame(bimatrix)
+    NEs_expected = [([0, 0, 1], [1, 0]),
+                    ([0, 0, 1], [2/3, 1/3]),
+                    ([2/3, 1/3, 0], [1/3, 2/3])]
+    qhull_options = 'QJ'
+    NEs_computed = vertex_enumeration(g, qhull_options=qhull_options)
+    eq_(len(NEs_computed), len(NEs_expected))
+    for NEs in (NEs_computed, NEs_expected):
+        NEs.sort(key=lambda x: (list(x[1]), list(x[0])))
+    for actions_computed, actions in zip(NEs_computed, NEs_expected):
+        for action_computed, action in zip(actions_computed, actions):
+            assert_allclose(action_computed, action, atol=1e-10)
+
+
 @raises(TypeError)
 def test_vertex_enumeration_invalid_g():
     bimatrix = [[(3, 3), (3, 2)],

--- a/quantecon/game_theory/vertex_enumeration.py
+++ b/quantecon/game_theory/vertex_enumeration.py
@@ -14,7 +14,7 @@ import scipy.spatial
 from numba import jit, guvectorize
 
 
-def vertex_enumeration(g):
+def vertex_enumeration(g, qhull_options=None):
     """
     Compute mixed-action Nash equilibria of a 2-player normal form game
     by enumeration and matching of vertices of the best response
@@ -32,16 +32,20 @@ def vertex_enumeration(g):
     g : NormalFormGame
         NormalFormGame instance with 2 players.
 
+    qhull_options : str, optional(default=None)
+        Options to pass to `scipy.spatial.ConvexHull`. See the `Qhull
+        manual <http://www.qhull.org>`_  for details.
+
     Returns
     -------
     list(tuple(ndarray(float, ndim=1)))
         List containing tuples of Nash equilibrium mixed actions.
 
     """
-    return list(vertex_enumeration_gen(g))
+    return list(vertex_enumeration_gen(g, qhull_options=qhull_options))
 
 
-def vertex_enumeration_gen(g):
+def vertex_enumeration_gen(g, qhull_options=None):
     """
     Generator version of `vertex_enumeration`.
 
@@ -49,6 +53,10 @@ def vertex_enumeration_gen(g):
     ----------
     g : NormalFormGame
         NormalFormGame instance with 2 players.
+
+    qhull_options : str, optional(default=None)
+        Options to pass to `scipy.spatial.ConvexHull`. See the `Qhull
+        manual <http://www.qhull.org>`_  for details.
 
     Yields
     -------
@@ -63,7 +71,9 @@ def vertex_enumeration_gen(g):
     if N != 2:
         raise NotImplementedError('Implemented only for 2-player games')
 
-    brps = [_BestResponsePolytope(g.players[1-i], idx=i) for i in range(N)]
+    brps = [_BestResponsePolytope(
+        g.players[1-i], idx=i, qhull_options=qhull_options
+    ) for i in range(N)]
 
     labelings_bits_tup = \
         tuple(_ints_arr_to_bits(brps[i].labelings) for i in range(N))
@@ -166,6 +176,10 @@ class _BestResponsePolytope:
     idx : scalar(int), optional(default=0)
         Player index in the normal form game, either 0 or 1.
 
+    qhull_options : str, optional(default=None)
+        Options to pass to `scipy.spatial.ConvexHull`. See the `Qhull
+        manual <http://www.qhull.org>`_  for details.
+
     Attributes
     ----------
     ndim : scalar(int)
@@ -191,7 +205,7 @@ class _BestResponsePolytope:
         `-equations[k, :-1]/equations[k, -1] + 1/trans_recip`.
 
     """
-    def __init__(self, opponent_player, idx=0):
+    def __init__(self, opponent_player, idx=0, qhull_options=None):
         try:
             num_opponents = opponent_player.num_opponents
         except AttributeError:
@@ -232,7 +246,7 @@ class _BestResponsePolytope:
         )
 
         # Create scipy.spatial.ConvexHull
-        self.hull = scipy.spatial.ConvexHull(D)
+        self.hull = scipy.spatial.ConvexHull(D, qhull_options=qhull_options)
 
         self.equations = self.hull.equations
         self.labelings = self.hull.simplices


### PR DESCRIPTION
For *some* degenerate games, `qhull_options='QJ'` helps to identify all the Nash equilibria:

```py
bimatrix = [[(0, 3), (6, 1)],
            [(2, 2), (5, 6)],
            [(3, 3), (3, 3)]]
g = gt.NormalFormGame(bimatrix)
```

```py
gt.vertex_enumeration(g)
```

```py
[(array([0.66666667, 0.33333333, 0.        ]),
  array([0.33333333, 0.66666667]))]
```

```py
gt.vertex_enumeration(g, qhull_options='QJ')
```

```py
[(array([0., 0., 1.]), array([1., 0.])),
 (array([0.0000000e+00, 3.9409863e-11, 1.0000000e+00]),
  array([0.66666667, 0.33333333])),
 (array([0.66666667, 0.33333333, 0.        ]),
  array([0.33333333, 0.66666667]))]
```

but not always:

```py
g = gt.NormalFormGame((2, 2))  # payoffs all zero
```

```py
gt.vertex_enumeration(g)
```

```py
[(array([1., 0.]), array([1., 0.]))]
```

```py
gt.vertex_enumeration(g, qhull_options='QJ')
```

```py
[(array([1., 0.]), array([0., 1.]))]
```