### PR TITLE
FIX: Force tuple elements to have the same dtype

### DIFF
--- a/quantecon/game_theory/support_enumeration.py
+++ b/quantecon/game_theory/support_enumeration.py
@@ -85,7 +85,7 @@ def _support_enumeration_gen(payoff_matrices):
     n_min = min(nums_actions)
 
     for k in range(1, n_min+1):
-        supps = (np.arange(k), np.empty(k, np.int_))
+        supps = (np.arange(0, k, 1, np.int_), np.empty(k, np.int_))
         actions = (np.empty(k+1), np.empty(k+1))
         A = np.empty((k+1, k+1))
 


### PR DESCRIPTION
Fix #434

Note that `np.arange(k, dtype=np.int_)` does not work in `nopython` mode; see https://github.com/numba/numba/issues/2643#issuecomment-363472901.