### PR TITLE
Isolate rtd-specific requirements to doc-requirements.txt

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+ipython
+numpydoc

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,21 +1,8 @@
 # These are the required packages for the quantecon package to build
-
-sphinx
-
-ipython
-
 numpy
-
-numpydoc
-
 scipy
-
 pandas
-
 statsmodels
-
 sympy
-
 numba
-
 requests

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -2,7 +2,6 @@
 numpy
 scipy
 pandas
-statsmodels
 sympy
 numba
 requests

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,4 +7,4 @@ python:
   version: 3.6
   setup_py_install: true
 
-requirements_file: pip-requirements.txt
+requirements_file: doc-requirements.txt


### PR DESCRIPTION
There are too many requirements in order to build the docs. However, there is no way to test if this patch works unless it is merged, so I am merging it into the `update-docs` branch.