### PR TITLE
Travis: Install numpy with OpenBLAS instead of MKL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,11 @@ before_install:
   #- sudo ln -s /run/shm /dev/shm
 
 install:
+  - pip install coveralls coverage flake8
+  # catch flake8 error before anything else
+  - flake8 --ignore=F401,E501,E226,E231,W291,E241 quantecon
   - conda install -c conda-forge --yes python=$TRAVIS_PYTHON_VERSION ipython numpy scipy nose pandas pip sympy pytables statsmodels numba
     # To Install Full Anaconda Stack (conda install --yes python=$TRAVIS_PYTHON_VERSION anaconda)
-  - pip install coveralls coverage
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   #- sudo ln -s /run/shm /dev/shm
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION ipython numpy scipy nose pandas pip sympy pytables statsmodels numba
+  - conda install -c conda-forge --yes python=$TRAVIS_PYTHON_VERSION ipython numpy scipy nose pandas pip sympy pytables statsmodels numba
     # To Install Full Anaconda Stack (conda install --yes python=$TRAVIS_PYTHON_VERSION anaconda)
   - pip install coveralls coverage
   - python setup.py install

--- a/quantecon/tests/util.py
+++ b/quantecon/tests/util.py
@@ -51,12 +51,8 @@ def get_data_dir():
 
 def get_h5_data_file():
     """
-<<<<<<< HEAD
     return the data file used for holding test data. If the data
     directory or file do not exist, they are created.
-=======
-    return the data file used for holding test data
->>>>>>> master
 
     Notes
     -----


### PR DESCRIPTION
By default, conda installs the non-FLOSS version of numpy, which bloats the installation size by 204.4 MB compressed (~600 MB uncompressed). This slows down the cache creation, even though now the `conda install` time has decreased from ~113s to ~11s.

See also: https://github.com/conda-forge/numpy-feedstock/issues/84