### PR TITLE
quad: Import sympy only when necessary

### DIFF
--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -6,7 +6,6 @@ TODO: 1. Fix warnings concerning casting complex variables back to floats
 """
 import numpy as np
 from numpy import conj, pi
-from scipy.signal import dimpulse, freqz, dlsim
 from .util import check_random_state
 
 
@@ -61,7 +60,6 @@ class ARMA:
         processing we desire.  Corresponds with the theta values
 
     """
-
     def __init__(self, phi, theta=0, sigma=1):
         self._phi, self._theta = phi, theta
         self.sigma = sigma
@@ -165,6 +163,7 @@ class ARMA:
             We take psi[0] as unity.
 
         """
+        from scipy.signal import dimpulse
         sys = self.ma_poly, self.ar_poly, 1
         times, psi = dimpulse(sys, n=impulse_length)
         psi = psi[0].flatten()  # Simplify return value into flat array
@@ -205,6 +204,7 @@ class ARMA:
             The frequency response
 
         """
+        from scipy.signal import freqz
         w, h = freqz(self.ma_poly, self.ar_poly, worN=res, whole=two_pi)
         spect = h * conj(h) * self.sigma**2
 
@@ -249,6 +249,7 @@ class ARMA:
             A simulation of the model that corresponds to this class
 
         """
+        from scipy.signal import dlsim
         random_state = check_random_state(random_state)
 
         sys = self.ma_poly, self.ar_poly, 1

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -14,7 +14,6 @@ import math
 import numpy as np
 import scipy.linalg as la
 from numba import jit, vectorize
-import sympy as sym
 from .ce_util import ckron, gridmake
 from .util import check_random_state
 
@@ -141,6 +140,7 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     random_state = check_random_state(random_state)
 
     if equidist_pp is None:
+        import sympy as sym
         equidist_pp = np.sqrt(np.array(list(sym.primerange(0, 7920))))
 
     n, a, b = list(map(np.atleast_1d, list(map(np.asarray, [n, a, b]))))

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -89,10 +89,12 @@ def _probvec(r, out):
     out[n] = 1 - r[n-1]
 
 _probvec_parallel = guvectorize(
-    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='parallel'
+    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='parallel',
+    cache=True
     )(_probvec)
 _probvec_cpu = guvectorize(
-    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='cpu'
+    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='cpu',
+    cache=True
     )(_probvec)
 
 

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -20,7 +20,6 @@ TODO
 """
 
 import os
-import requests
 import warnings
 
 #-Remote Structure-#
@@ -72,6 +71,7 @@ def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDE
     by setting ``overwrite=True``.
 
     """
+    import requests
 
     #-Generate Common Data Structure-#
     if type(files) == list:


### PR DESCRIPTION
This ~partially addresses~ fixes #449. The `import quantecon` time on my machine decreases from ~5.4s to ~4.6s~ to ~1s.