### PR TITLE
Travis: Disable performance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-coverage --cover-package=quantecon
+  - nosetests --with-coverage -a "!slow" --cover-package=quantecon
 
 after_success:
   - coveralls
+  # Enable this to occasionally test performance
+  # - nosetests -a "slow"


### PR DESCRIPTION
They should be run only from time to time, e.g. between releases, or
when the commit specifically states the perf modification of the
relevant code.

This fixes #109.