### PR TITLE
FIX: Raise correct error when `A` is not square in `LinearStateSpace`

### DIFF
--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -110,16 +110,17 @@ class LinearStateSpace:
         ni, nj = self.A.shape
         if ni != nj:
             raise ValueError(
-                "Matrix A (shape: %s) needs to be square" % (self.A.shape))
+                "Matrix A (shape: %s) needs to be square" % (self.A.shape, ))
         if ni != self.C.shape[0]:
             raise ValueError(
-                "Matrix C (shape: %s) does not have compatible dimensions with A. "
-                "It should be shape: %s" % (self.C.shape, (ni, 1)))
+                "Matrix C (shape: %s) does not have compatible dimensions "
+                "with A. It should be shape: %s" % (self.C.shape, (ni, 1)))
         self.m = self.C.shape[1]
         self.k, self.n = self.G.shape
         if self.n != ni:
-            raise ValueError("Matrix G (shape: %s) does not have compatible dimensions with A (%s)"%(
-                self.G.shape, self.A.shape))
+            raise ValueError("Matrix G (shape: %s) does not have compatible"
+                             "dimensions with A (%s)" % (self.G.shape,
+                                                         self.A.shape))
         if H is None:
             self.H = None
             self.l = None

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 from quantecon.lss import LinearStateSpace
+from nose.tools import raises
 
 
 class TestLinearStateSpace(unittest.TestCase):
@@ -63,6 +64,15 @@ class TestLinearStateSpace(unittest.TestCase):
 
         assert_allclose(xval[0], expected_output)
         assert_allclose(yval[0], expected_output)
+
+
+@raises(ValueError)
+def test_non_square_A():
+    A = np.zeros((1, 2))
+    C = np.zeros((1, 1))
+    G = np.zeros((1, 1))
+
+    LinearStateSpace(A, C, G)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently:

```python
A = np.zeros((1, 2))
C = np.zeros((1, 1))
G = np.zeros((1, 1))

qe.LinearStateSpace(A, C, G)
```

raises

```
TypeError: not all arguments converted during string formatting
```

This PR fixes `lss.py` so that the correct error is raised when `A` is not a square matrix.