### PR TITLE
Add drift term keyword to `markov.tauchen`.

### DIFF
--- a/quantecon/markov/tests/test_approximation.py
+++ b/quantecon/markov/tests/test_approximation.py
@@ -16,13 +16,21 @@ class TestTauchen(unittest.TestCase):
         self.n = np.random.random_integers(3, 25)
         self.m = np.random.random_integers(4)
         self.tol = 1e-12
+        self.b = 0.
 
-        mc = tauchen(self.rho, self.sigma_u, self.m, self.n)
+        mc = tauchen(self.rho, self.sigma_u, self.b, self.m, self.n)
         self.x, self.P = mc.state_values, mc.P
 
     def tearDown(self):
         del self.x
         del self.P
+
+    def testStateCenter(self):
+        for b in [0., 1., -1.]:
+            mu = b / (1 - self.rho)
+            mc = tauchen(self.rho, self.sigma_u, b, self.m, self.n)
+            self.assertTrue(np.allclose(mu, np.mean(mc.state_values),
+                                        atol=self.tol))
 
     def testShape(self):
         i, j = self.P.shape


### PR DESCRIPTION
Try to make `markov.tauchen` able to handle non-zero drift term in the AR(1) process.

[Here](https://nbviewer.jupyter.org/github/shizejin/Notebooks/blob/master/AR%281%29%20with%20drift%20term.ipynb) discusses the logic of modification made.