### PR TITLE
FIX: DOC: Remove `matplotlib.sphinxext.only_directives`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ except ImportError:
 #         def __getattr__(cls, name):
 #             return Mock()
 
-#     MOCK_MODULES = ['pandas', 'statsmodels', 'numba'] 						 
+#     MOCK_MODULES = ['pandas', 'statsmodels', 'numba']
 #     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -82,7 +82,7 @@ extensions = [
     # 'ipython_console_highlighting',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
-    'matplotlib.sphinxext.only_directives',
+    # 'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
 ]
 

--- a/quantecon/optimize/scalar_maximization.py
+++ b/quantecon/optimize/scalar_maximization.py
@@ -37,16 +37,13 @@ def brent_max(func, a, b, args=(), xtol=1e-5, maxiter=500):
         attained.  A value of 0 implies that the maximum was not hit.
         The value `num_iter` is the number of function calls.
 
-    Example
-    -------
-
-    ```
-        @njit
-        def f(x):
-            return -(x + 2.0)**2 + 1.0
-
-        xf, fval, info = brent_max(f, -2, 2)
-    ```
+    Examples
+    --------
+    >>> @njit
+    ... def f(x):
+    ...     return -(x + 2.0)**2 + 1.0
+    ...
+    >>> xf, fval, info = brent_max(f, -2, 2)
 
     """
     if not np.isfinite(a):


### PR DESCRIPTION
See #460.
Just removed `matplotlib.sphinxext.only_directives` in `docs/source/conf.py`. It works fine on my environment with Anaconda.