### PR TITLE
Add `LQMarkov`.

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -29,7 +29,7 @@ from .inequality import lorenz_curve, gini_coefficient, shorrocks_index
 from .kalman import Kalman
 from .lae import LAE
 from .arma import ARMA
-from .lqcontrol import LQ
+from .lqcontrol import LQ, LQMarkov
 from .filter import hamilton_filter
 from .lqnash import nnash
 from .lss import LinearStateSpace

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -1,14 +1,16 @@
 """
 Provides a class called LQ for solving linear quadratic control
-problems.
+problems, and a class called LQMarkov for solving Markov jump
+linear quadratic control problems.
 
 """
 from textwrap import dedent
 import numpy as np
 from numpy import dot
 from scipy.linalg import solve
-from .matrix_eqn import solve_discrete_riccati
+from .matrix_eqn import solve_discrete_riccati, solve_discrete_riccati_system
 from .util import check_random_state
+from .markov import MarkovChain
 
 
 class LQ:
@@ -327,3 +329,282 @@ class LQ:
         x_path[:, T] = Ax + Bu + Cw_path[:, T]
 
         return x_path, u_path, w_path
+
+
+class LQMarkov:
+    r"""
+    This class is for analyzing Markov jump linear quadratic optimal
+    control problems of the infinite horizon form
+
+    .. math::
+
+        \min \mathbb{E}
+        \Big[ \sum_{t=0}^{\infty} \beta^t r(x_t, s_t, u_t) \Big]
+
+    with
+
+    .. math::
+
+         r(x_t, s_t, u_t) :=
+            (x_t' R(s_t) x_t + u_t' Q(s_t) u_t + 2 u_t' N(s_t) x_t)
+
+    subject to the law of motion
+
+    .. math::
+
+         x_{t+1} = A(s_t) x_t + B(s_t) u_t + C(s_t) w_{t+1}
+
+    Here :math:`x` is n x 1, :math:`u` is k x 1, :math:`w` is j x 1 and the
+    matrices are conformable for these dimensions.  The sequence :math:`{w_t}`
+    is assumed to be white noise, with zero mean and
+    :math:`\mathbb{E} [ w_t' w_t ] = I`, the j x j identity.
+
+    If :math:`C` is not supplied as a parameter, the model is assumed to be
+    deterministic (and :math:`C` is set to a zero matrix of appropriate
+    dimension).
+
+    The optimal value function :math:`V(x_t, s_t)` takes the form
+
+    .. math::
+
+         x_t' P(s_t) x_t + d(s_t)
+
+    and the optimal policy is of the form :math:`u_t = -F(s_t) x_t`.
+
+    Parameters
+    ----------
+    Π : array_like(float, ndim=2)
+        The Markov chain transition matrix with dimension m x m.
+    Qs : array_like(float)
+        Consists of m symmetric and non-negative definite payoff
+        matrices Q(s) with dimension k x k that corresponds with
+        the control variable u for each Markov state s
+    Rs : array_like(float)
+        Consists of m symmetric and non-negative definite payoff
+        matrices R(s) with dimension n x n that corresponds with
+        the state variable x for each Markov state s
+    As : array_like(float)
+        Consists of m state transition matrices A(s) with dimension
+        n x n for each Markov state s
+    Bs : array_like(float)
+        Consists of m state transition matrices B(s) with dimension
+        n x k for each Markov state s
+    Cs : array_like(float), optional(default=None)
+        Consists of m state transition matrices C(s) with dimension
+        n x j for each Markov state s. If the model is deterministic
+        then Cs should take default value of None
+    Ns : array_like(float), optional(default=None)
+        Consists of m cross product term matrices N(s) with dimension
+        k x n for each Markov state,
+    beta : scalar(float), optional(default=1)
+        beta is the discount parameter
+
+    Attributes
+    ----------
+    Π, Qs, Rs, Ns, As, Bs, Cs, beta : see Parameters
+    Ps : array_like(float)
+        Ps is part of the value function representation of
+        :math:`V(x, s) = x' P(s) x + d(s)`
+    ds : array_like(float)
+        ds is part of the value function representation of
+        :math:`V(x, s) = x' P(s) x + d(s)`
+    Fs : array_like(float)
+        Fs is the policy rule that determines the choice of control in
+        each period at each Markov state
+    m : scalar(int)
+        The number of Markov states
+    k, n, j : scalar(int)
+        The dimensions of the matrices as presented above
+
+    """
+
+    def __init__(self, Π, Qs, Rs, As, Bs, Cs=None, Ns=None, beta=1):
+
+        # == Make sure all matrices for each state are 2D arrays == #
+        def converter(Xs):
+            return np.array([np.atleast_2d(np.asarray(X, dtype='float'))
+                             for X in Xs])
+        self.As, self.Bs, self.Qs, self.Rs = list(map(converter,
+                                                      (As, Bs, Qs, Rs)))
+
+        # == Record number of states == #
+        self.m = self.Qs.shape[0]
+        # == Record dimensions == #
+        self.k, self.n = self.Qs.shape[1], self.Rs.shape[1]
+
+        if Ns is None:
+            # == No cross product term in payoff. Set N=0. == #
+            Ns = [np.zeros((self.k, self.n)) for i in range(self.m)]
+
+        self.Ns = converter(Ns)
+
+        if Cs is None:
+            # == If C not given, then model is deterministic. Set C=0. == #
+            self.j = 1
+            Cs = [np.zeros((self.n, self.j)) for i in range(self.m)]
+
+        self.Cs = converter(Cs)
+        self.j = self.Cs.shape[2]
+
+        self.beta = beta
+
+        self.Π = np.asarray(Π, dtype='float')
+
+        self.Ps = None
+        self.ds = None
+        self.Fs = None
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        m = """\
+        Markov Jump Linear Quadratic control system
+          - beta (discount parameter)       : {b}
+          - T (time horizon)                : {t}
+          - m (number of Markov states)     : {m}
+          - n (number of state variables)   : {n}
+          - k (number of control variables) : {k}
+          - j (number of shocks)            : {j}
+        """
+        t = "infinite"
+        return dedent(m.format(b=self.beta, m=self.m, n=self.n, k=self.k,
+                               j=self.j, t=t))
+
+    def stationary_values(self):
+        """
+        Computes the matrix :math:`P(s)` and scalar :math:`d(s)` that
+        represent the value function
+
+        .. math::
+
+             V(x, s) = x' P(s) x + d(s)
+
+        in the infinite horizon case.  Also computes the control matrix
+        :math:`F` from :math:`u = - F(s) x`.
+
+        Returns
+        -------
+        Ps : array_like(float)
+            Ps is part of the value function representation of
+            :math:`V(x, s) = x' P(s) x + d(s)`
+        ds : array_like(float)
+            ds is part of the value function representation of
+            :math:`V(x, s) = x' P(s) x + d(s)`
+        Fs : array_like(float)
+            Fs is the policy rule that determines the choice of control in
+            each period at each Markov state
+
+        """
+
+        # == Simplify notations == #
+        beta, Π = self.beta, self.Π
+        m, n, k = self.m, self.n, self.k
+        As, Bs, Cs = self.As, self.Bs, self.Cs
+        Qs, Rs, Ns = self.Qs, self.Rs, self.Ns
+
+        # == Solve for P(s) by iterating discrete riccati system== #
+        Ps = solve_discrete_riccati_system(Π, As, Bs, Cs, Qs, Rs, Ns, beta)
+
+        # == calculate F and d == #
+        Fs = np.array([np.empty((k, n)) for i in range(m)])
+        X = np.empty((m, m))
+        sum1, sum2 = np.empty((k, k)), np.empty((k, n))
+        for i in range(m):
+            # CCi = C_i C_i'
+            CCi = Cs[i] @ Cs[i].T
+            sum1[:, :] = 0.
+            sum2[:, :] = 0.
+            for j in range(m):
+                # for F
+                sum1 += beta * Π[i, j] * Bs[i].T @ Ps[j] @ Bs[i]
+                sum2 += beta * Π[i, j] * Bs[i].T @ Ps[j] @ As[i]
+
+                # for d
+                X[j, i] = np.trace(Ps[j] @ CCi)
+
+            Fs[i][:, :] = solve(Qs[i] + sum1, sum2 + Ns[i])
+
+        ds = solve(np.eye(m) - beta * Π,
+                   np.diag(beta * Π @ X).reshape((m, 1))).flatten()
+
+        self.Ps, self.ds, self.Fs = Ps, ds, Fs
+
+        return Ps, ds, Fs
+
+    def compute_sequence(self, x0, ts_length=None, random_state=None):
+        """
+        Compute and return the optimal state and control sequences
+        :math:`x_0, ..., x_T` and :math:`u_0,..., u_T`  under the
+        assumption that :math:`{w_t}` is iid and :math:`N(0, 1)`,
+        with Markov states sequence :math:`s_0, ..., s_T`
+
+        Parameters
+        ----------
+        x0 : array_like(float)
+            The initial state, a vector of length n
+
+        ts_length : scalar(int), optional(default=None)
+            Length of the simulation. If None, T is set to be 100
+
+        random_state : int or np.random.RandomState, optional
+            Random seed (integer) or np.random.RandomState instance to set
+            the initial state of the random number generator for
+            reproducibility. If None, a randomly initialized RandomState is
+            used.
+
+        Returns
+        -------
+        x_path : array_like(float)
+            An n x T+1 matrix, where the t-th column represents :math:`x_t`
+
+        u_path : array_like(float)
+            A k x T matrix, where the t-th column represents :math:`u_t`
+
+        w_path : array_like(float)
+            A j x T+1 matrix, where the t-th column represent :math:`w_t`
+
+        state : array_like(int)
+            Array containing the state values :math:`s_t` of the sample path
+
+        """
+
+        # === solve for optimal policies === #
+        self.stationary_values()
+
+        # === Simplify notation === #
+        As, Bs, Cs = self.As, self.Bs, self.Cs
+        Fs = self.Fs
+
+        random_state = check_random_state(random_state)
+        x0 = np.asarray(x0)
+        x0 = x0.reshape(self.n, 1)
+
+        T = ts_length if ts_length else 100
+
+        # == Simulate Markov states == #
+        chain = MarkovChain(self.Π)
+        state = chain.simulate_indices(ts_length=T+1,
+                                       random_state=random_state)
+
+        # == Prepare storage arrays == #
+        x_path = np.empty((self.n, T+1))
+        u_path = np.empty((self.k, T))
+        w_path = random_state.randn(self.j, T+1)
+        Cw_path = np.empty((self.n, T+1))
+        for i in range(T+1):
+            Cw_path[:, i] = Cs[state[i]] @ w_path[:, i]
+
+        # == Use policy sequence to generate states and controls == #
+        x_path[:, 0] = x0.flatten()
+        u_path[:, 0] = - (Fs[state[0]] @ x0).flatten()
+        for t in range(1, T):
+            Ax = As[state[t]] @ x_path[:, t-1]
+            Bu = Bs[state[t]] @ u_path[:, t-1]
+            x_path[:, t] = Ax + Bu + Cw_path[:, t]
+            u_path[:, t] = - (Fs[state[t]] @ x_path[:, t])
+        Ax = As[state[T]] @ x_path[:, T-1]
+        Bu = Bs[state[T]] @ u_path[:, T-1]
+        x_path[:, T] = Ax + Bu + w_path[:, T]
+
+        return x_path, u_path, w_path, state

--- a/quantecon/tests/test_lqcontrol.py
+++ b/quantecon/tests/test_lqcontrol.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 from numpy import dot
-from quantecon.lqcontrol import LQ
+from quantecon.lqcontrol import LQ, LQMarkov
 
 
 class TestLQControl(unittest.TestCase):
@@ -91,6 +91,144 @@ class TestLQControl(unittest.TestCase):
             assert_allclose(val_func_lq, val_func_answer, atol=1e-3)
 
 
+class TestLQMarkov(unittest.TestCase):
+
+    def setUp(self):
+
+        # Markove chain transition matrix
+        Π = np.array([[0.8, 0.2],
+                      [0.2, 0.8]])
+
+        # discount rate
+        beta = .95
+
+        # scalar case
+        q1, q2 = 1., .5
+        r1, r2 = 1., .5
+        a1, a2 = .95, .9
+        b1, b2 = -1., -.5
+
+        self.lq_markov_scalar = LQMarkov(Π, [q1, q2], [r1, r2], [a1, a2],
+                                         [b1, b2], beta=beta)
+        # matrix case
+        Π = np.array([[0.8, 0.2],
+                      [0.2, 0.8]])
+
+        Qs = np.array([[[0.9409]], [[0.870489]]])
+        Rs = np.array([[[1., 0., 1.],
+                        [0., 0., 0.],
+                        [1., 0., 1.]],
+                       [[1., 0., 1.],
+                        [0., 0., 0.],
+                        [1., 0., 1.]]])
+        Ns = np.array([[[-0.97, 0., -0.97]],
+                       [[-0.933, 0., -0.933]]])
+        As = np.array([[[0., 0., 0.],
+                        [0., 1., 0.],
+                        [0., 5., 0.8]],
+                       [[0., 0., 0.],
+                        [0., 1., 0.],
+                        [0., 5., 0.8]]])
+        B = np.array([[1., 0., 0.]]).T
+        Bs = [B, B]
+        C = np.array([[0., 0., 1.]]).T
+        Cs = [C, C]
+
+        self.lq_markov_mat1 = LQMarkov(Π, Qs, Rs, As, Bs,
+                                       Cs=Cs, Ns=Ns, beta=0.95)
+        self.lq_markov_mat2 = LQMarkov(Π, Qs, Rs, As, Bs,
+                                       Cs=Cs, Ns=Ns, beta=1.05)
+
+    def tearDown(self):
+        del self.lq_markov_scalar
+        del self.lq_markov_mat1
+        del self.lq_markov_mat2
+
+    def test_print(self):
+        print(self.lq_markov_scalar)
+        print(self.lq_markov_mat1)
+
+    def test_scalar_sequences_with_seed(self):
+
+        lq_markov_scalar = self.lq_markov_scalar
+        x0 = 2
+
+        expected_x_seq = np.array([[2., 1.15977567, 1.20677567]])
+        expected_u_seq = np.array([[1.28044866, 0.7425166]])
+        expected_w_seq = np.array([[1.3486939, 0.55721062, 0.53423587]])
+        expected_state = np.array([1, 1, 1])
+
+        x_seq, u_seq, w_seq, state = \
+            lq_markov_scalar.compute_sequence(x0, ts_length=2,
+                                              random_state=1234)
+
+        assert_allclose(x_seq, expected_x_seq, atol=1e-6)
+        assert_allclose(u_seq, expected_u_seq, atol=1e-6)
+        assert_allclose(w_seq, expected_w_seq, atol=1e-6)
+        assert_allclose(state, expected_state, atol=1e-6)
+
+    def test_stationary_scalar(self):
+
+        lq_markov_scalar = self.lq_markov_scalar
+
+        P_answer = np.array([[[1.51741465]],
+                             [[1.07334181]]])
+        d_answer = np.array([0., 0.])
+        F_answer = np.array([[[-0.54697435]],
+                             [[-0.64022433]]])
+
+        Ps, ds, Fs = lq_markov_scalar.stationary_values()
+
+        assert_allclose(F_answer, Fs, atol=1e-6)
+        assert_allclose(P_answer, Ps, atol=1e-6)
+        assert_allclose(d_answer, ds, atol=1e-6)
+
+    def test_mat_sequences(self):
+
+        lq_markov_mat = self.lq_markov_mat1
+        x0 = np.array([[1000, 1, 25]])
+
+        expected_x_seq = np.array([[1.00000000e+03, 1.01490556e+03],
+                                   [1.00000000e+00, 2.18454431e+00],
+                                   [2.50000000e+01, 2.61845443e+01]])
+        expected_u_seq = np.array([[1013.72101253]])
+        expected_w_seq = np.array([[0.41782708, 1.18454431]])
+        expected_state = np.array([1, 1])
+
+        x_seq, u_seq, w_seq, state = \
+            lq_markov_mat.compute_sequence(x0, ts_length=1, random_state=1234)
+
+        assert_allclose(x_seq, expected_x_seq, atol=1e-6)
+        assert_allclose(u_seq, expected_u_seq, atol=1e-6)
+        assert_allclose(w_seq, expected_w_seq, atol=1e-6)
+        assert_allclose(state, expected_state, atol=1e-6)
+
+    def test_stationary_mat(self):
+        lq_markov_mat = self.lq_markov_mat1
+
+        d_answer = np.array([16.2474886, 16.31935939])
+        P_answer = np.array([[[4.5144056e-02, 1.8627227e+01, 1.9348906e-01],
+                              [1.8627227e+01, 7.9343733e+03, 8.0055130e+01],
+                              [1.9348906e-01, 8.0055130e+01, 8.2991316e-01]],
+                             [[5.3606323e-02, 2.0136657e+01, 2.1763323e-01],
+                              [2.0136657e+01, 7.8100167e+03, 8.1960509e+01],
+                              [2.1763323e-01, 8.1960509e+01, 8.8413147e-01]]])
+        F_answer = np.array([[[-0.98437714, 19.2051657, -0.83142157]],
+                             [[-1.01434303, 21.58480004, -0.83851124]]])
+
+        Ps, ds, Fs = lq_markov_mat.stationary_values()
+
+        assert_allclose(F_answer, Fs, atol=1e-6)
+        assert_allclose(P_answer, Ps, atol=1e-6)
+        assert_allclose(d_answer, ds, atol=1e-6)
+
+    def test_raise_error(self):
+        # test raising error for not converging
+        lq_markov_mat = self.lq_markov_mat2
+
+        self.assertRaises(ValueError, lq_markov_mat.stationary_values)
+
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestLQControl)
-    unittest.TextTestRunner(verbosity=2, stream=sys.stderr).run(suite)
+    for Test in [TestLQControl, TestLQMarkov]:
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+        unittest.TextTestRunner(verbosity=2, stream=sys.stderr).run(suite)


### PR DESCRIPTION
Integrating the code for solving Markov jump LQ dynamic programming problems from the [notebook](https://github.com/QuantEcon/python_lecture_sandpit/blob/master/source/rst/tax_smoothing_1.rst) in the sandpit repository.

The modifications I have made comparing to the original code:

1. modify the notations to be consistent with the existing `LQ` class,
2. discard the usage of `dict` and adopt `ndarray` to store transition, payoff matrices, policies, and value function arrays,
3. arrange the part of matrix calculation to make it easier to read and more efficient.
4. add tests.

[Here](https://nbviewer.jupyter.org/github/shizejin/Notebooks/blob/master/Demonstration%20of%20%60qe.LQ_Markov%60.ipynb) is a demonstration for this `qe.LQ_Markov` class.

Two points that I would like to have your opinions before I move on:

1. the original code only applies to the case with infinite horizon. I am wondering if I should try to add code for finite horizon case as well?
2. parallelization over Markov states during iterations of the stacked system of discrete riccati equations could be very beneficial for the cases with large number of Markov states. Shall we try to explore whether we want to implement this or not?

I will add more tests in the next few days.