### PR TITLE
TRAVIS: Set coverage branch as `linux`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ script:
   - nosetests --with-coverage -a "!slow" --cover-package=quantecon
 
 after_success:
-  - coveralls
+  - |
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        coveralls
+    fi
   # Enable this to occasionally test performance
   # - nosetests -a "slow"


### PR DESCRIPTION
Only submit coverage reports from the `linux` build job.