### PR TITLE
UPD: Update travis to use python=3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 
 matrix:
   include:
-    - python: 3.6
+    - python: 3.7
     - os: osx
       osx_image: xcode10
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 
 sudo: false        #Use new Container Infrastructure
 language: python
+dist: xenial
 
 cache:
   pip: true


### PR DESCRIPTION
This PR updates travis to use `python=3.7` from `python=3.6` as that aligns with the latest `anaconda` distribution release. 