### PR TITLE
FIX: two minor modifications in `lqcontrol`

### DIFF
--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -605,6 +605,6 @@ class LQMarkov:
             u_path[:, t] = - (Fs[state[t]] @ x_path[:, t])
         Ax = As[state[T]] @ x_path[:, T-1]
         Bu = Bs[state[T]] @ u_path[:, T-1]
-        x_path[:, T] = Ax + Bu + w_path[:, T]
+        x_path[:, T] = Ax + Bu + Cw_path[:, T]
 
         return x_path, u_path, w_path, state

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -298,7 +298,8 @@ class LQ:
         # == Preliminaries, infinite horizon case == #
         else:
             T = ts_length if ts_length else 100
-            self.stationary_values(method=method)
+            if self.P is None:
+                self.stationary_values(method=method)
 
         # == Set up initial condition and arrays to store paths == #
         random_state = check_random_state(random_state)
@@ -570,7 +571,8 @@ class LQMarkov:
         """
 
         # === solve for optimal policies === #
-        self.stationary_values()
+        if self.Ps is None:
+            self.stationary_values()
 
         # === Simplify notation === #
         As, Bs, Cs = self.As, self.Bs, self.Cs

--- a/quantecon/tests/test_lqcontrol.py
+++ b/quantecon/tests/test_lqcontrol.py
@@ -95,7 +95,7 @@ class TestLQMarkov(unittest.TestCase):
 
     def setUp(self):
 
-        # Markove chain transition matrix
+        # Markov chain transition matrix
         Π = np.array([[0.8, 0.2],
                       [0.2, 0.8]])
 
@@ -153,7 +153,7 @@ class TestLQMarkov(unittest.TestCase):
         lq_markov_scalar = self.lq_markov_scalar
         x0 = 2
 
-        expected_x_seq = np.array([[2., 1.15977567, 1.20677567]])
+        expected_x_seq = np.array([[2., 1.15977567, 0.6725398]])
         expected_u_seq = np.array([[1.28044866, 0.7425166]])
         expected_w_seq = np.array([[1.3486939, 0.55721062, 0.53423587]])
         expected_state = np.array([1, 1, 1])
@@ -188,8 +188,8 @@ class TestLQMarkov(unittest.TestCase):
         lq_markov_mat = self.lq_markov_mat1
         x0 = np.array([[1000, 1, 25]])
 
-        expected_x_seq = np.array([[1.00000000e+03, 1.01490556e+03],
-                                   [1.00000000e+00, 2.18454431e+00],
+        expected_x_seq = np.array([[1.00000000e+03, 1.01372101e+03],
+                                   [1.00000000e+00, 1.00000000e+00],
                                    [2.50000000e+01, 2.61845443e+01]])
         expected_u_seq = np.array([[1013.72101253]])
         expected_w_seq = np.array([[0.41782708, 1.18454431]])


### PR DESCRIPTION
I made two fixes  for `LQ` and `LQMarkov` classes.

1. There was a typo in calculating the values of the last period states for `LQMarkov` models. I forgot to left multiply the `C` matrix to the vector of shocks. I have fixed this and modified tests correspondingly.

2. The code was computing stationary values each time we call `compute_series`, which is unnecessary since the optimal policy `F` are stored as class attribute and do not change. This increases running time especially for lectures that simulate multiple paths for the same model, e.g. "How to Pay for a War: Part 1". I modified it to only compute stationary values once when `compute_series` method is called for the first time. By doing so, the running time of "How to Pay for a War: Part 1" decreases from `42s` to `12s`.

The first point is closely related to the work about the series of Markov Jump LQ DP lectures. I feel sorry that I fail to spot this typo. It would be great if we can make another release before we publish those lectures. However, since this bug only matters for values in the last period and almost has no influence on the patterns of the graphs that we draw, I guess it will also be fine that we publish lectures first and include these fixes in a release with other commits later.