### PR TITLE
FIX: random.draw: Replace `random_sample` with `random`

### DIFF
--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -200,13 +200,13 @@ def draw(cdf, size=None):
     """
     if isinstance(size, types.Integer):
         def draw_impl(cdf, size):
-            rs = np.random.random_sample(size)
+            rs = np.random.random(size)
             out = np.empty(size, dtype=np.int_)
             for i in range(size):
                 out[i] = searchsorted(cdf, rs[i])
             return out
     else:
         def draw_impl(cdf, size):
-            r = np.random.random_sample()
+            r = np.random.random()
             return searchsorted(cdf, r)
     return draw_impl


### PR DESCRIPTION
Fix #502

This is a bug of Numba 0.45.0-0.45.1, which has been fixed by numba/numba#4431 on Numba master. It will take some time to be released, so use `random` in place of `random_sample`.