### PR TITLE
[FIX] Fix Future Warnings in ivp.py and test_quad.py and RuntimeError in lq_control.py.

### DIFF
--- a/quantecon/ivp.py
+++ b/quantecon/ivp.py
@@ -127,8 +127,8 @@ class IVP(integrate.ode):
 
         # rhs of ode evaluated along approximate solution
         T = ti.size
-        rhs_ode = np.vstack(self.f(ti[i], soln[i, 1:], *self.f_params)
-                            for i in range(T))
+        rhs_ode = np.vstack([self.f(ti[i], soln[i, 1:], *self.f_params)
+                            for i in range(T)])
         rhs_ode = np.hstack((ti[:, np.newaxis], rhs_ode))
 
         # should be roughly zero everywhere (if approximation is any good!)

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -241,7 +241,10 @@ class LQ:
         F = solve(S1, S2)
 
         # == Compute d == #
-        d = self.beta * np.trace(dot(P, dot(C, C.T))) / (1 - self.beta)
+        if self.beta == 1:
+            d = 0
+        else:
+            d = self.beta * np.trace(dot(P, dot(C, C.T))) / (1 - self.beta)
 
         # == Bind states and return values == #
         self.P, self.F, self.d = P, F, d

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -145,6 +145,10 @@ class LQ:
             self.d = None
             self.T = None
 
+            if (self.C != 0).any() and beta >= 1:
+                raise ValueError('beta must be strictly smaller than 1 if ' +
+                'T = None and C != 0.')
+
         self.F = None
 
     def __repr__(self):

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -147,7 +147,7 @@ class LQ:
 
             if (self.C != 0).any() and beta >= 1:
                 raise ValueError('beta must be strictly smaller than 1 if ' +
-                'T = None and C != 0.')
+                    'T = None and C != 0.')
 
         self.F = None
 

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -115,7 +115,7 @@ class TestQuadrect(unittest.TestCase):
             for kind in kinds:
                 for num in n:
                     num_in = num ** 2 if len(kind) == 1 else num
-                    quad_rect_res1d.ix[func_name, num][kind] = quadrect(func,
+                    quad_rect_res1d.loc[func_name, num][kind] = quadrect(func,
                                                                         num_in,
                                                                         a, b,
                                                                         kind)
@@ -136,10 +136,10 @@ class TestQuadrect(unittest.TestCase):
 
         for num in n:
             for kind in kinds2[:4]:
-                data2.ix[num**2][kind] = quadrect(f1_2, [num, num],
+                data2.loc[num**2][kind] = quadrect(f1_2, [num, num],
                                                   a[0], b[0], kind)
             for kind in kinds2[4:]:
-                data2.ix[num**2][kind] = quadrect(f1_2, num**2, a[0],
+                data2.loc[num**2][kind] = quadrect(f1_2, num**2, a[0],
                                                   b[0], kind)
 
         cls.data2d1 = data2
@@ -151,7 +151,7 @@ class TestQuadrect(unittest.TestCase):
 
         for num in n3:
             for kind in kinds2[3:]:
-                data3.ix[num][kind] = quadrect(f2_2, num, a[1], b[1], kind)
+                data3.loc[num][kind] = quadrect(f2_2, num, a[1], b[1], kind)
 
         cls.data2d2 = data3
 

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -46,9 +46,9 @@ class TestRBLQControl(unittest.TestCase):
 
         # the *_pf endings refer to an example with pure forecasting
         # (see p171 in Robustness)
-        self.rblq_test = RBLQ(Q, R, A, B, C, beta, theta)
-        self.rblq_test_pf = RBLQ(Q_pf, R, A, B_pf, C, beta, theta)
-        self.lq_test = LQ(Q, R, A, B, C, beta)
+        self.rblq_test = RBLQ(Q, R, A, B, C, beta=beta, theta=theta)
+        self.rblq_test_pf = RBLQ(Q_pf, R, A, B_pf, C, beta=beta, theta=theta)
+        self.lq_test = LQ(Q, R, A, B, C, beta=beta)
         self.methods = ['doubling', 'qz']
 
     def tearDown(self):

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -46,8 +46,8 @@ class TestRBLQControl(unittest.TestCase):
 
         # the *_pf endings refer to an example with pure forecasting
         # (see p171 in Robustness)
-        self.rblq_test = RBLQ(Q, R, A, B, C, beta=beta, theta=theta)
-        self.rblq_test_pf = RBLQ(Q_pf, R, A, B_pf, C, beta=beta, theta=theta)
+        self.rblq_test = RBLQ(Q, R, A, B, C, beta, theta)
+        self.rblq_test_pf = RBLQ(Q_pf, R, A, B_pf, C, beta, theta)
         self.lq_test = LQ(Q, R, A, B, C, beta=beta)
         self.methods = ['doubling', 'qz']
 


### PR DESCRIPTION
This PR fixes some warnings raised in issues \#505 \#506 and \#507.

1) FutureWarning in `ivp.py` (see issue \#505).

2) RuntimeError in `lq_control.py` (see issue \#506)

3) Pandas related future warnings in `test_quad.py` (see issue \#507).

This is my first QuantEcon PR so let me know if I need to fix anything.