### PR TITLE
[WIP] Extend `lss` and `kalman` with correlated state and measurement noises.

### DIFF
--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -10,7 +10,6 @@ https://lectures.quantecon.org/py/linear_models.html
 
 from textwrap import dedent
 import numpy as np
-from numpy.random import multivariate_normal
 from scipy.linalg import solve
 from numba import jit
 from .util import check_random_state

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -47,7 +47,7 @@ class TestLinearStateSpace(unittest.TestCase):
 
             sim = ss.simulate(ts_length=250)
             for arr in sim:
-                self.assertTrue(len(arr[0])==250)
+                self.assertTrue(len(arr[0]) == 250)
 
     def test_simulate_with_seed(self):
         expected_xval = np.array([[0.75, 0.6959564924, 0.6485540613,
@@ -61,7 +61,6 @@ class TestLinearStateSpace(unittest.TestCase):
         for i, ss in enumerate(self.ss_vec):
 
             xval, yval = ss.simulate(ts_length=5, random_state=5)
-            
 
             assert_allclose(xval[0], expected_xval[i])
             assert_allclose(yval[0], expected_yval[i])
@@ -87,8 +86,9 @@ class TestLinearStateSpace(unittest.TestCase):
         for i, ss in enumerate(self.ss_vec):
 
             xval, yval = ss.replicate(T=100, num_reps=5, random_state=5)
-            expected_output = np.array([0.0251787033, 0.1908734072, -0.1813300321,
-                                        0.2305923028, -0.0412238313])
+            expected_output = np.array([0.0251787033, 0.1908734072,
+                                        -0.1813300321, 0.2305923028,
+                                        -0.0412238313])
 
             assert_allclose(xval[0], expected_xval[i])
             assert_allclose(yval[0], expected_yval[i])
@@ -106,4 +106,3 @@ def test_non_square_A():
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestLinearStateSpace)
     unittest.TextTestRunner(verbosity=2, stream=sys.stderr).run(suite)
-

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -17,53 +17,81 @@ class TestLinearStateSpace(unittest.TestCase):
         A = .95
         C = .05
         G = 1.
+        H = 1.
+        V = .01
         mu_0 = .75
 
-        self.ss = LinearStateSpace(A, C, G, mu_0=mu_0)
+        self.ss_vec = []
+        self.ss_vec.append(LinearStateSpace(A, C, G, mu_0=mu_0))
+        self.ss_vec.append(LinearStateSpace(A, C, G, H=H, V=V, mu_0=mu_0))
 
     def tearDown(self):
-        del self.ss
+        for ss in self.ss_vec:
+
+            del ss
 
     def test_stationarity(self):
-        vals = self.ss.stationary_distributions(max_iter=1000, tol=1e-9)
-        ssmux, ssmuy, sssigx, sssigy = vals
+        for ss in self.ss_vec:
 
-        self.assertTrue(abs(ssmux - ssmuy) < 2e-8)
-        self.assertTrue(abs(sssigx - sssigy) < 2e-8)
-        self.assertTrue(abs(ssmux) < 2e-8)
-        self.assertTrue(abs(sssigx - self.ss.C**2/(1 - self.ss.A**2)) < 2e-8)
+            vals = ss.stationary_distributions(max_iter=1000, tol=1e-9)
+            ssmux, ssmuy, sssigx, sssigy = vals
+
+            self.assertTrue(abs(ssmux - ssmuy) < 2e-8)
+            if (ss.H is None) & (ss.G == 1.).all():
+                self.assertTrue(abs(sssigx - sssigy) < 2e-8)
+            self.assertTrue(abs(ssmux) < 2e-8)
+            self.assertTrue(abs(sssigx - ss.C**2/(1 - ss.A**2)) < 2e-8)
 
     def test_simulate(self):
-        ss = self.ss
+        for ss in self.ss_vec:
 
-        sim = ss.simulate(ts_length=250)
-        for arr in sim:
-            self.assertTrue(len(arr[0])==250)
+            sim = ss.simulate(ts_length=250)
+            for arr in sim:
+                self.assertTrue(len(arr[0])==250)
 
     def test_simulate_with_seed(self):
-        ss = self.ss
+        expected_xval = np.array([[0.75, 0.6959564924, 0.6485540613,
+                                   0.6952504141, 0.6309060605],
+                                  [0.75, 0.8282543714, 0.7896838925,
+                                   0.7215239351, 0.6887068618]])
+        expected_yval = np.array([[0.75, 0.6959564924, 0.6485540613,
+                                   0.6952504141, 0.6309060605],
+                                  [0.4179363134, 0.5761084508, 2.3726112765,
+                                   0.1297952303, 0.3594226235]])
+        for i, ss in enumerate(self.ss_vec):
 
-        xval, yval = ss.simulate(ts_length=5, random_state=5)
-        expected_output = np.array([0.75 , 0.73456137, 0.6812898, 0.76876387,
-                                    .71772107])
+            xval, yval = ss.simulate(ts_length=5, random_state=5)
+            
 
-        assert_allclose(xval[0], expected_output)
-        assert_allclose(yval[0], expected_output)
+            assert_allclose(xval[0], expected_xval[i])
+            assert_allclose(yval[0], expected_yval[i])
 
     def test_replicate(self):
-        xval, yval = self.ss.replicate(T=100, num_reps=5000)
+        for ss in self.ss_vec:
 
-        assert_allclose(xval, yval)
-        self.assertEqual(xval.size, 5000)
-        self.assertLessEqual(abs(np.mean(xval)), .05)
+            xval, yval = ss.replicate(T=100, num_reps=5000)
+            if ss.H is None:
+                assert_allclose(xval, yval)
+            self.assertEqual(xval.size, 5000)
+            self.assertLessEqual(abs(np.mean(xval)), .05)
 
     def test_replicate_with_seed(self):
-        xval, yval = self.ss.replicate(T=100, num_reps=5, random_state=5)
-        expected_output = np.array([0.06871204, 0.06937119, -0.1478022,
-                                    0.23841252, -0.06823762])
+        expected_xval = np.array([[0.0251787033, 0.1908734072, -0.1813300321,
+                                   0.2305923028, -0.0412238313],
+                                  [0.0989884088, 0.12561899, -0.2316570774,
+                                   0.1019641968, 0.3374819642]])
+        expected_yval = np.array([[0.0251787033, 0.1908734072, -0.1813300321,
+                                   0.2305923028, -0.0412238313],
+                                  [-1.0522559176, 0.8107821779, -1.3791302245,
+                                   0.9976912727, -0.0693582509]])
+        for i, ss in enumerate(self.ss_vec):
 
-        assert_allclose(xval[0], expected_output)
-        assert_allclose(yval[0], expected_output)
+            xval, yval = ss.replicate(T=100, num_reps=5, random_state=5)
+            expected_output = np.array([0.0251787033, 0.1908734072, -0.1813300321,
+                                        0.2305923028, -0.0412238313])
+
+            assert_allclose(xval[0], expected_xval[i])
+            assert_allclose(yval[0], expected_yval[i])
 
 
 @raises(ValueError)


### PR DESCRIPTION
Extend the code of linear state space model and Kalman filter to allow for dependent state noise `w` and measurement noise `v`. The following lists changes made or to be made.

1. `lss.py`: Linear State Space Model

- [x]  `__init__`: add the covariance matrix `V` as a keyword argument
- [x]  `simulate`: simulate `w` and `v` in the same time by constructing a concatenated variance-covariance matrix, and calling `random_state.multivariate_normal`
- [x]  `replicate`: record `x_T` and `y_T` together in each simulation, rather than simulating `x_T` first and then simulating `y_T` by simulating `v` separately as the existing code is doing
- [x]  `moment_sequence`: the updating rules for means are unchanged; the updating rule of Sigma_y is changed form `Sigma_y = G @ Sigma_x @ G.T + H @ H.T` to `Sigma_y = G @ Sigma_x @ G.T + G @ V + H @ H.T`
- [x]  `stationary_distributions`: unchanged.
- [x]  `geometric_sums`: unchanged
- [x]  `impulse_response`: unchanged
- [x]  add tests

2. `kalman.py`: Kalman Filter

- [ ]  `prior_to_filtered`: unchanged
- [ ]  `filtered_to_forecast`: need to derive new formulas for forecasting moments when there is correlation between noises
- [x] `stationary_values`: use more general formulas of riccati equation and Kalman gain with the covariance matrix `V`
- [ ]  `whitener_lss`, `stationary_coefficients`, `stationary_innovation_covar`
- [ ]  add tests
