### PR TITLE
Fix lgtm warning for arma.py.

### DIFF
--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -5,7 +5,6 @@ TODO: 1. Fix warnings concerning casting complex variables back to floats
 
 """
 import numpy as np
-from numpy import conj
 from .util import check_random_state
 
 
@@ -206,7 +205,7 @@ class ARMA:
         """
         from scipy.signal import freqz
         w, h = freqz(self.ma_poly, self.ar_poly, worN=res, whole=two_pi)
-        spect = h * conj(h) * self.sigma**2
+        spect = h * np.conj(h) * self.sigma**2
 
         return w, spect
 


### PR DESCRIPTION
This PR addresses [this](https://lgtm.com/projects/g/QuantEcon/QuantEcon.py/snapshot/b54e85c50aa0535bdea6982134df2936c0805a03/files/quantecon/arma.py?sort=name&dir=ASC&mode=heatmap#xa8bed9b397d1f709:1) lgtm code quality suggestion.