### PR TITLE
rank_size_plot_typo

### DIFF
--- a/quantecon/inequality.py
+++ b/quantecon/inequality.py
@@ -144,7 +144,7 @@ def rank_size_plot(data, ax, label=None, c=1.0):
         for plotting on, has method ax.loglog
     """
     w = - np.sort(- data)                  # Reverse sort
-    w = w[:int(len(w) * c)]                # extract top c%
+    w = w[:int(len(w) * c)]                # extract top (c * 100)%
     rank_data = np.arange(len(w)) + 1
     size_data = w
     ax.loglog(rank_data, size_data, 'o', markersize=3.0, alpha=0.5, label=label)


### PR DESCRIPTION
Thanks @jstac and @mmcky . This PR corrects the following typo in the source file of a function ``quantecon.inequality.rank_size_plot`` in the library ``QuantEcon``, please see [here](https://quanteconpy.readthedocs.io/en/latest/_modules/quantecon/inequality.html#rank_size_plot):
- change ``c%`` in the comment ``extract top c%`` to ``(c * 100)%``.

It fixes #543 .