### PR TITLE
FIX: rank-size test by inc. sample size

### DIFF
--- a/quantecon/tests/test_inequality.py
+++ b/quantecon/tests/test_inequality.py
@@ -103,7 +103,8 @@ def test_rank_size():
     of the size of the distribution.
     """
 
-    sample_size = 1000
+    np.random.seed(15)
+    sample_size = 10000
     c = 0.74
 
     # Tests Pareto; r_squared ~ 1
@@ -116,10 +117,9 @@ def test_rank_size():
     _, _, r_value, _, _ = linregress(np.log(rank_data), np.log(size_data))
     r_sqval = r_value**2
 
-    assert_allclose(r_sqval, 1, rtol=1e-4)
+    assert_allclose(r_sqval, 1, rtol=1e-3)
 
     # Tests Exponential; r_squared < 1
-    np.random.seed(13)
     z = np.random.randn(sample_size)
 
     exp_draw = np.exp(z)
@@ -129,6 +129,5 @@ def test_rank_size():
                                          np.log(size_data_exp))
     r_sqval_exp = r_value_exp**2
 
-    assert_raises(AssertionError, assert_allclose, r_sqval_exp, 1, rtol=1e-4)
-
+    assert_raises(AssertionError, assert_allclose, r_sqval_exp, 1, rtol=1e-3)
 


### PR DESCRIPTION
As mentioned in PR #551 the test for `rank_size` method checks for linearity in the output log-log plot. I did this by performing linear regression of `log(size_data)` on `log(rank_data)` and comparing the resulting `r_squared` value to 1.

Turns out an error tolerance of `1e-4` for a sample size of `1000` was a little optimistic. I have increased the sample size to `10000`, reduced the tolerance to `1e-3` and the comparison works as expected now.

Another mistake was setting the seed for exponential draw but not the Pareto draw, I've fixed that as well. I'm not sure if setting a seed here is a good practice in the first place, if not I can remove it and increase sample size / reduce tolerance further.

Please let me know if this is an acceptable fix. This should close #553.