### PR TITLE
Update root_finding.py

### DIFF
--- a/quantecon/optimize/root_finding.py
+++ b/quantecon/optimize/root_finding.py
@@ -247,7 +247,7 @@ def newton_secant(func, x0, args=(), tol=1.48e-8, maxiter=50,
         p1 = x0 * (1 + 1e-4) + 1e-4
     else:
         p1 = x0 * (1 + 1e-4) - 1e-4
-        q0 = func(p0, *args)
+    q0 = func(p0, *args)
     funcalls += 1
     q1 = func(p1, *args)
     funcalls += 1


### PR DESCRIPTION
when x0 >= 0, q0 is not initially assigned, but since this function is jitted, I believe q0 = 0.0 when referenced before assignment

to notice the error, remove @njit decorator and set x0 >= 0