### PR TITLE
FIX: Fix ImportError for `gcd`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
         exclude:
           - os: windows-latest
             python-version: 3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         exclude:
           - os: windows-latest
             python-version: 3.7

--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -5,7 +5,7 @@ Tools for dealing with a directed graph.
 import numpy as np
 from scipy import sparse
 from scipy.sparse import csgraph
-from fractions import gcd
+from math import gcd
 from numba import jit
 
 from .util import check_random_state

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -80,7 +80,7 @@ classes*. For each :math:`S_m` and each :math:`i \in S_m`, we have
 
 """
 import numbers
-from fractions import gcd
+from math import gcd
 import numpy as np
 from scipy import sparse
 from numba import jit


### PR DESCRIPTION
`fractions.gcd` has been switched to `math.gcd` and is now deprecated in python 3.9.