### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/sphinxext/ipython_console_highlighting.py
+++ b/docs/sphinxext/ipython_console_highlighting.py
@@ -81,7 +81,7 @@ class IPythonConsoleLexer(Lexer):
                 curcode += line[continue_prompt.end():]
             elif output_prompt is not None:
                 # Use the 'error' token for output.  We should probably make
-                # our own token, but error is typicaly in a bright color like
+                # our own token, but error is typically in a bright color like
                 # red, so it works fine for our output prompts.
                 insertions.append((len(curcode),
                                    [(0, Generic.Error, output_prompt.group())]))

--- a/docs/sphinxext/ipython_directive.py
+++ b/docs/sphinxext/ipython_directive.py
@@ -46,7 +46,7 @@ ToDo
 Authors
 -------
 
-- John D Hunter: orignal author.
+- John D Hunter: original author.
 - Fernando Perez: refactoring, documentation, cleanups, port to 0.11.
 - VĂĄclavĹ milauer <eudoxos-AT-arcig.cz>: Prompt generalizations.
 - Skipper Seabold, refactoring, cleanups, pure python addition

--- a/quantecon/compute_fp.py
+++ b/quantecon/compute_fp.py
@@ -63,7 +63,7 @@ def compute_fixed_point(T, v, error_tol=1e-3, max_iter=50, verbose=2,
     routine. It finds an approximate fixed point of `T`, a point
     :math:`v^*` such that :math:`\lVert T(v) - v\rVert \leq
     \mathrm{error\_tol}`, provided `T` is a function that satisfies the
-    assumptions of Brouwer's fixed point theorm, i.e., a continuous
+    assumptions of Brouwer's fixed point theorem, i.e., a continuous
     function that maps a compact and convex set to itself.
 
     Parameters

--- a/quantecon/estspec.py
+++ b/quantecon/estspec.py
@@ -75,9 +75,9 @@ def periodogram(x, window=None, window_len=7):
 
         I(w) = \frac{1}{n} \Big[ \sum_{t=0}^{n-1} x_t e^{itw} \Big] ^2
 
-    at the Fourier frequences :math:`w_j := \frac{2 \pi j}{n}`,
+    at the Fourier frequencies :math:`w_j := \frac{2 \pi j}{n}`,
     :math:`j = 0, \dots, n - 1`, using the fast Fourier transform. Only the
-    frequences :math:`w_j` in :math:`[0, \pi]` and corresponding values
+    frequencies :math:`w_j` in :math:`[0, \pi]` and corresponding values
     :math:`I(w_j)` are returned. If a window type is given then smoothing
     is performed.
 
@@ -94,9 +94,9 @@ def periodogram(x, window=None, window_len=7):
     Returns
     -------
     w : array_like(float)
-        Fourier frequences at which periodogram is evaluated
+        Fourier frequencies at which periodogram is evaluated
     I_w : array_like(float)
-        Values of periodogram at the Fourier frequences
+        Values of periodogram at the Fourier frequencies
 
     """
     n = len(x)
@@ -128,9 +128,9 @@ def ar_periodogram(x, window='hanning', window_len=7):
     Returns
     -------
     w : array_like(float)
-        Fourier frequences at which periodogram is evaluated
+        Fourier frequencies at which periodogram is evaluated
     I_w : array_like(float)
-        Values of periodogram at the Fourier frequences
+        Values of periodogram at the Fourier frequencies
 
     """
     # === run regression === #

--- a/quantecon/filter.py
+++ b/quantecon/filter.py
@@ -13,7 +13,7 @@ def hamilton_filter(data, h, *args):
     
     Parameters
     ----------
-    data : arrray or dataframe
+    data : array or dataframe
     h : integer
         Time horizon that we are likely to predict incorrectly.
         Original paper recommends 2 for annual data, 8 for quarterly data,

--- a/quantecon/game_theory/pure_nash.py
+++ b/quantecon/game_theory/pure_nash.py
@@ -35,7 +35,7 @@ def pure_nash_brute(g, tol=None):
     [(1, 1)]
 
     If we consider the "Matching Pennies" game, which has no pure nash
-    equilibirum:
+    equilibrium:
 
     >>> MP_bimatrix = [[(1, -1), (-1, 1)],
     ...                [(-1, 1), (1, -1)]]

--- a/quantecon/game_theory/tests/test_vertex_enumeration.py
+++ b/quantecon/game_theory/tests/test_vertex_enumeration.py
@@ -79,7 +79,7 @@ class TestBestResponsePolytope:
                     [(0, 3), (6, 1)]]
         g = NormalFormGame(bimatrix)
 
-        # Original best reponse polytope for player 0
+        # Original best response polytope for player 0
         vertices_P = np.array([
             [0, 0, 0],       # 0
             [1/3, 0, 0],     # a
@@ -103,7 +103,7 @@ class TestBestResponsePolytope:
         self.labelings_P = labelings_P[ind]
         self.vertices_P = vertices_P[ind]
 
-        # Translated best reponse polytope for player 0
+        # Translated best response polytope for player 0
         self.brp0 = _BestResponsePolytope(g.players[1], idx=0)
 
     def test_best_response_polytope(self):

--- a/quantecon/game_theory/vertex_enumeration.py
+++ b/quantecon/game_theory/vertex_enumeration.py
@@ -186,7 +186,7 @@ class _BestResponsePolytope:
         Dimension of the polytope.
 
     hull : scipy.spatial.ConvexHull
-        `ConvexHull` instance reprensenting the polar polytope.
+        `ConvexHull` instance representing the polar polytope.
 
     num_vertices : scalar(int)
         Number of the vertices identified by `ConvexHull`.

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -71,7 +71,7 @@ class LQ:
         non-negative definite
     R : array_like(float)
         R is the payoff (or cost) matrix that corresponds with the
-        state variable x and is n x n. Should be symetric and
+        state variable x and is n x n. Should be symmetric and
         non-negative definite
     A : array_like(float)
         A is part of the state transition as described above. It should
@@ -93,7 +93,7 @@ class LQ:
     Rf : array_like(float), optional(default=None)
         Rf is the final (in a finite horizon model) payoff(or cost)
         matrix that corresponds with the control variable u and is n x
-        n.  Should be symetric and non-negative definite
+        n.  Should be symmetric and non-negative definite
 
     Attributes
     ----------

--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -245,7 +245,7 @@ class LinearStateSpace:
     def moment_sequence(self):
         r"""
         Create a generator to calculate the population mean and
-        variance-convariance matrix for both :math:`x_t` and :math:`y_t`
+        variance-covariance matrix for both :math:`x_t` and :math:`y_t`
         starting at the initial condition (self.mu_0, self.Sigma_0).
         Each iteration produces a 4-tuple of items (mu_x, mu_y, Sigma_x,
         Sigma_y) for the next period.

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -56,7 +56,7 @@ class TestDiscreteDP:
             res_init = ddp.solve(method='value_iteration', v_init=v_init,
                                  epsilon=self.epsilon)
 
-            # Check v is an epsilon/2-approxmation of v_star
+            # Check v is an epsilon/2-approximation of v_star
             ok_(np.abs(res.v - self.v_star).max() < self.epsilon/2)
             ok_(np.abs(res_init.v - self.v_star).max() < self.epsilon/2)
 
@@ -89,7 +89,7 @@ class TestDiscreteDP:
                                  v_init=v_init,
                                  epsilon=self.epsilon)
 
-            # Check v is an epsilon/2-approxmation of v_star
+            # Check v is an epsilon/2-approximation of v_star
             ok_(np.abs(res.v - self.v_star).max() < self.epsilon/2)
             ok_(np.abs(res_init.v - self.v_star).max() < self.epsilon/2)
 
@@ -103,7 +103,7 @@ class TestDiscreteDP:
             res = ddp.solve(method='modified_policy_iteration',
                             epsilon=self.epsilon, k=k)
 
-            # Check v is an epsilon/2-approxmation of v_star
+            # Check v is an epsilon/2-approximation of v_star
             ok_(np.abs(res.v - self.v_star).max() < self.epsilon/2)
 
             # Check sigma == sigma_star

--- a/quantecon/tests/test_ivp.py
+++ b/quantecon/tests/test_ivp.py
@@ -241,7 +241,7 @@ def test_solve_variable_trajectory():
 
 
 def test_interpolation():
-    """Testing parameteric B-spline interpolation methods."""
+    """Testing parametric B-spline interpolation methods."""
 
     # compute some fixed length trajectories
     t0, k0 = 0, np.array([5.0])

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -39,7 +39,7 @@ def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDE
                 A list of files to specify a collection of filenames	
                 A dict of dir : list(files) to specify a directory
     repo        str, optional(default=REPO)
-    raw 		str, optional(defualt=RAW)
+    raw 		str, optional(default=RAW)
     			This is here in case github changes access to their raw files through web links
     branch      str, optional(default=BRANCH)
     folder      str, optional(default=FOLDER)


### PR DESCRIPTION
There are small typos in:
- docs/sphinxext/ipython_console_highlighting.py
- docs/sphinxext/ipython_directive.py
- quantecon/compute_fp.py
- quantecon/estspec.py
- quantecon/filter.py
- quantecon/game_theory/pure_nash.py
- quantecon/game_theory/tests/test_vertex_enumeration.py
- quantecon/game_theory/vertex_enumeration.py
- quantecon/lqcontrol.py
- quantecon/lss.py
- quantecon/markov/tests/test_ddp.py
- quantecon/tests/test_ivp.py
- quantecon/util/notebooks.py

Fixes:
- Should read `approximation` rather than `approxmation`.
- Should read `response` rather than `reponse`.
- Should read `frequencies` rather than `frequences`.
- Should read `typically` rather than `typicaly`.
- Should read `theorem` rather than `theorm`.
- Should read `symmetric` rather than `symetric`.
- Should read `representing` rather than `reprensenting`.
- Should read `parametric` rather than `parameteric`.
- Should read `original` rather than `orignal`.
- Should read `equilibrium` rather than `equilibirum`.
- Should read `default` rather than `defualt`.
- Should read `array` rather than `arrray`.
- Should read `covariance` rather than `convariance`.

Closes #583