### PR TITLE
LGTM code quality suggestions

### DIFF
--- a/quantecon/game_theory/__init__.py
+++ b/quantecon/game_theory/__init__.py
@@ -13,5 +13,7 @@ from .support_enumeration import support_enumeration, support_enumeration_gen
 from .lemke_howson import lemke_howson
 from .mclennan_tourky import mclennan_tourky
 from .vertex_enumeration import vertex_enumeration, vertex_enumeration_gen
-from .game_generators import *
+from .game_generators import (
+    blotto_game, ranking_game, sgc_game, tournament_game, unit_vector_game
+)
 from .repeated_game import RepeatedGame

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -6,7 +6,6 @@ linear quadratic control problems.
 """
 from textwrap import dedent
 import numpy as np
-from numpy import dot
 from scipy.linalg import solve
 from .matrix_eqn import solve_discrete_riccati, solve_discrete_riccati_system
 from .util import check_random_state
@@ -186,15 +185,15 @@ class LQ:
         Q, R, A, B, N, C = self.Q, self.R, self.A, self.B, self.N, self.C
         P, d = self.P, self.d
         # == Some useful matrices == #
-        S1 = Q + self.beta * dot(B.T, dot(P, B))
-        S2 = self.beta * dot(B.T, dot(P, A)) + N
-        S3 = self.beta * dot(A.T, dot(P, A))
+        S1 = Q + self.beta * np.dot(B.T, np.dot(P, B))
+        S2 = self.beta * np.dot(B.T, np.dot(P, A)) + N
+        S3 = self.beta * np.dot(A.T, np.dot(P, A))
         # == Compute F as (Q + B'PB)^{-1} (beta B'PA + N) == #
         self.F = solve(S1, S2)
         # === Shift P back in time one step == #
-        new_P = R - dot(S2.T, self.F) + S3
+        new_P = R - np.dot(S2.T, self.F) + S3
         # == Recalling that trace(AB) = trace(BA) == #
-        new_d = self.beta * (d + np.trace(dot(P, dot(C, C.T))))
+        new_d = self.beta * (d + np.trace(np.dot(P, np.dot(C, C.T))))
         # == Set new state == #
         self.P, self.d = new_P, new_d
 
@@ -240,15 +239,15 @@ class LQ:
         P = solve_discrete_riccati(A0, B0, R, Q, N, method=method)
 
         # == Compute F == #
-        S1 = Q + self.beta * dot(B.T, dot(P, B))
-        S2 = self.beta * dot(B.T, dot(P, A)) + N
+        S1 = Q + self.beta * np.dot(B.T, np.dot(P, B))
+        S2 = self.beta * np.dot(B.T, np.dot(P, A)) + N
         F = solve(S1, S2)
 
         # == Compute d == #
         if self.beta == 1:
             d = 0
         else:
-            d = self.beta * np.trace(dot(P, dot(C, C.T))) / (1 - self.beta)
+            d = self.beta * np.trace(np.dot(P, np.dot(C, C.T))) / (1 - self.beta)
 
         # == Bind states and return values == #
         self.P, self.F, self.d = P, F, d
@@ -315,7 +314,7 @@ class LQ:
         x_path = np.empty((self.n, T+1))
         u_path = np.empty((self.k, T))
         w_path = random_state.randn(self.j, T+1)
-        Cw_path = dot(C, w_path)
+        Cw_path = np.dot(C, w_path)
 
         # == Compute and record the sequence of policies == #
         policies = []
@@ -327,13 +326,13 @@ class LQ:
         # == Use policy sequence to generate states and controls == #
         F = policies.pop()
         x_path[:, 0] = x0.flatten()
-        u_path[:, 0] = - dot(F, x0).flatten()
+        u_path[:, 0] = - np.dot(F, x0).flatten()
         for t in range(1, T):
             F = policies.pop()
-            Ax, Bu = dot(A, x_path[:, t-1]), dot(B, u_path[:, t-1])
+            Ax, Bu = np.dot(A, x_path[:, t-1]), np.dot(B, u_path[:, t-1])
             x_path[:, t] = Ax + Bu + Cw_path[:, t]
-            u_path[:, t] = - dot(F, x_path[:, t])
-        Ax, Bu = dot(A, x_path[:, T-1]), dot(B, u_path[:, T-1])
+            u_path[:, t] = - np.dot(F, x_path[:, t])
+        Ax, Bu = np.dot(A, x_path[:, T-1]), np.dot(B, u_path[:, T-1])
         x_path[:, T] = Ax + Bu + Cw_path[:, T]
 
         return x_path, u_path, w_path

--- a/quantecon/lqnash.py
+++ b/quantecon/lqnash.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy import dot, eye
 from scipy.linalg import solve
 from .util import check_random_state
 
@@ -107,8 +106,8 @@ def nnash(A, B1, B2, R1, R2, Q1, Q2, S1, S2, W1, W2, M1, M2,
         k_2 = B2.shape[1]
 
     random_state = check_random_state(random_state)
-    v1 = eye(k_1)
-    v2 = eye(k_2)
+    v1 = np.eye(k_1)
+    v2 = np.eye(k_2)
     P1 = np.zeros((n, n))
     P2 = np.zeros((n, n))
     F1 = random_state.randn(k_1, n)
@@ -119,28 +118,28 @@ def nnash(A, B1, B2, R1, R2, Q1, Q2, S1, S2, W1, W2, M1, M2,
         F10 = F1
         F20 = F2
 
-        G2 = solve(dot(B2.T, P2.dot(B2))+Q2, v2)
-        G1 = solve(dot(B1.T, P1.dot(B1))+Q1, v1)
-        H2 = dot(G2, B2.T.dot(P2))
-        H1 = dot(G1, B1.T.dot(P1))
+        G2 = solve(np.dot(B2.T, P2.dot(B2))+Q2, v2)
+        G1 = solve(np.dot(B1.T, P1.dot(B1))+Q1, v1)
+        H2 = np.dot(G2, B2.T.dot(P2))
+        H1 = np.dot(G1, B1.T.dot(P1))
 
         # break up the computation of F1, F2
-        F1_left = v1 - dot(H1.dot(B2)+G1.dot(M1.T),
+        F1_left = v1 - np.dot(H1.dot(B2)+G1.dot(M1.T),
                            H2.dot(B1)+G2.dot(M2.T))
-        F1_right = H1.dot(A)+G1.dot(W1.T) - dot(H1.dot(B2)+G1.dot(M1.T),
+        F1_right = H1.dot(A)+G1.dot(W1.T) - np.dot(H1.dot(B2)+G1.dot(M1.T),
                                                 H2.dot(A)+G2.dot(W2.T))
         F1 = solve(F1_left, F1_right)
-        F2 = H2.dot(A)+G2.dot(W2.T) - dot(H2.dot(B1)+G2.dot(M2.T), F1)
+        F2 = H2.dot(A)+G2.dot(W2.T) - np.dot(H2.dot(B1)+G2.dot(M2.T), F1)
 
         Lambda1 = A - B2.dot(F2)
         Lambda2 = A - B1.dot(F1)
-        Pi1 = R1 + dot(F2.T, S1.dot(F2))
-        Pi2 = R2 + dot(F1.T, S2.dot(F1))
+        Pi1 = R1 + np.dot(F2.T, S1.dot(F2))
+        Pi2 = R2 + np.dot(F1.T, S2.dot(F1))
 
-        P1 = dot(Lambda1.T, P1.dot(Lambda1)) + Pi1 - \
-             dot(dot(Lambda1.T, P1.dot(B1)) + W1 - F2.T.dot(M1), F1)
-        P2 = dot(Lambda2.T, P2.dot(Lambda2)) + Pi2 - \
-             dot(dot(Lambda2.T, P2.dot(B2)) + W2 - F1.T.dot(M2), F2)
+        P1 = np.dot(Lambda1.T, P1.dot(Lambda1)) + Pi1 - \
+             np.dot(np.dot(Lambda1.T, P1.dot(B1)) + W1 - F2.T.dot(M1), F1)
+        P2 = np.dot(Lambda2.T, P2.dot(Lambda2)) + Pi2 - \
+             np.dot(np.dot(Lambda2.T, P2.dot(B2)) + W2 - F1.T.dot(M2), F2)
 
         dd = np.max(np.abs(F10 - F1)) + np.max(np.abs(F20 - F2))
 

--- a/quantecon/matrix_eqn.py
+++ b/quantecon/matrix_eqn.py
@@ -10,7 +10,6 @@ TODO: 1. See issue 47 on github repository, should add support for
       2. Fix warnings from checking conditioning of matrices
 """
 import numpy as np
-from numpy import dot
 from numpy.linalg import solve
 from scipy.linalg import solve_discrete_lyapunov as sp_solve_discrete_lyapunov
 from scipy.linalg import solve_discrete_are as sp_solve_discrete_are
@@ -172,19 +171,19 @@ def solve_discrete_riccati(A, B, Q, R, N=None, tolerance=1e-10, max_iter=500,
     # == Choose optimal value of gamma in R_hat = R + gamma B'B == #
     current_min = np.inf
     candidates = (0.01, 0.1, 0.25, 0.5, 1.0, 2.0, 10.0, 100.0, 10e5)
-    BB = dot(B.T, B)
-    BTA = dot(B.T, A)
+    BB = np.dot(B.T, B)
+    BTA = np.dot(B.T, A)
     for gamma in candidates:
         Z = R + gamma * BB
         cn = np.linalg.cond(Z)
         if cn * EPS < 1:
-            Q_tilde = - Q + dot(N.T, solve(Z, N + gamma * BTA)) + gamma * I
-            G0 = dot(B, solve(Z, B.T))
-            A0 = dot(I - gamma * G0, A) - dot(B, solve(Z, N))
-            H0 = gamma * dot(A.T, A0) - Q_tilde
+            Q_tilde = - Q + np.dot(N.T, solve(Z, N + gamma * BTA)) + gamma * I
+            G0 = np.dot(B, solve(Z, B.T))
+            A0 = np.dot(I - gamma * G0, A) - np.dot(B, solve(Z, N))
+            H0 = gamma * np.dot(A.T, A0) - Q_tilde
             f1 = np.linalg.cond(Z, np.inf)
             f2 = gamma * f1
-            f3 = np.linalg.cond(I + dot(G0, H0))
+            f3 = np.linalg.cond(I + np.dot(G0, H0))
             f_gamma = max(f1, f2, f3)
             if f_gamma < current_min:
                 best_gamma = gamma
@@ -199,10 +198,10 @@ def solve_discrete_riccati(A, B, Q, R, N=None, tolerance=1e-10, max_iter=500,
     R_hat = R + gamma * BB
 
     # == Initial conditions == #
-    Q_tilde = - Q + dot(N.T, solve(R_hat, N + gamma * BTA)) + gamma * I
-    G0 = dot(B, solve(R_hat, B.T))
-    A0 = dot(I - gamma * G0, A) - dot(B, solve(R_hat, N))
-    H0 = gamma * dot(A.T, A0) - Q_tilde
+    Q_tilde = - Q + np.dot(N.T, solve(R_hat, N + gamma * BTA)) + gamma * I
+    G0 = np.dot(B, solve(R_hat, B.T))
+    A0 = np.dot(I - gamma * G0, A) - np.dot(B, solve(R_hat, N))
+    H0 = gamma * np.dot(A.T, A0) - Q_tilde
     i = 1
 
     # == Main loop == #
@@ -212,9 +211,9 @@ def solve_discrete_riccati(A, B, Q, R, N=None, tolerance=1e-10, max_iter=500,
             raise ValueError(fail_msg.format(i))
 
         else:
-            A1 = dot(A0, solve(I + dot(G0, H0), A0))
-            G1 = G0 + dot(dot(A0, G0), solve(I + dot(H0, G0), A0.T))
-            H1 = H0 + dot(A0.T, solve(I + dot(H0, G0), dot(H0, A0)))
+            A1 = np.dot(A0, solve(I + np.dot(G0, H0), A0))
+            G1 = G0 + np.dot(np.dot(A0, G0), solve(I + np.dot(H0, G0), A0.T))
+            H1 = H0 + np.dot(A0.T, solve(I + np.dot(H0, G0), np.dot(H0, A0)))
 
             error = np.max(np.abs(H1 - H0))
             A0 = A1


### PR DESCRIPTION
Hi all! 

This PR addresses the code quality alerts in #466 

Three different things that LGTM picked up in the repo: 

1. An `import *` in quantecon/game_theory/__init__.py. This one was a relatively straightforward fix, just updated with the specific imports required.
2. "wrong number of arguments" in quantecon/util/timing.py. I think this one is a false alarm - there is branching logic to distinguish between the no argument, one argument, and many argument cases. Triggered by a call in TestTicTacToc.test_loop.test_function_one_arg. **Have not made any changes to this code since I believe LGTM is mistaken here.**
3. Module (numpy) is imported with 'import' and 'import from' in a couple different files. This is triggered by an `import numpy as np` followed by `from numpy import dot` etc. which is pretty reasonable especially with big formulas with lots of linear algebra. I see two possible approaches here: 
      - Replace all `dot(A,B)` calls with `np.dot(A,B)`
      - Replace all `dot(A,B)` calls with `A.dot(B)` 

For completeness here I defaulted to the first approach since it's a one-to-one drop in replacement and won't require any significant rewrites. However it does not help with readability or brevity, so I can certainly drop those commits from the PR if need be. 
Happy to give the second approach a try as well. 

LGTM list for reference: https://lgtm.com/projects/g/QuantEcon/QuantEcon.py/alerts?mode=list

Looking forward to your feedback on this! Thanks,

Nick

