### PR TITLE
MAINT: Replace `np.int`

### DIFF
--- a/quantecon/game_theory/game_generators/bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/bimatrix_generators.py
@@ -197,7 +197,7 @@ def _populate_blotto_payoff_arrays(payoff_arrays, actions, values):
                     for p in range(2):
                         payoffs[p] += values[k, p] / 2
                 else:
-                    winner = np.int(actions[i, k] < actions[j, k])
+                    winner = np.intp(actions[i, k] < actions[j, k])
                     payoffs[winner] += values[k, winner]
             payoff_arrays[0][i, j], payoff_arrays[1][j, i] = payoffs
 

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -164,7 +164,7 @@ def _sample_without_replacement(n, r, out):
     # Logic taken from random.sample in the standard library
     pool = np.arange(n)
     for j in range(k):
-        idx = int(np.floor(r[j] * (n-j)))  # np.floor returns a float
+        idx = np.intp(np.floor(r[j] * (n-j)))  # np.floor returns a float
         out[j] = pool[idx]
         pool[idx] = pool[n-j-1]
 

--- a/quantecon/util/tests/test_numba.py
+++ b/quantecon/util/tests/test_numba.py
@@ -65,7 +65,7 @@ class TestCombJit:
 
         eq_(comb_jit(self.MAX_INTP, 2), 0)
 
-        N = np.int(self.MAX_INTP**0.5 * 2**0.5) + 1
+        N = np.intp(self.MAX_INTP**0.5 * 2**0.5) + 1
         eq_(comb_jit(N, 2), 0)
 
     def test_max_intp(self):


### PR DESCRIPTION
To remove ``DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`.``