### PR TITLE
ENH: Vectorize ECDF's `__call__` method

### DIFF
--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -51,4 +51,4 @@ class ECDF:
         def f(a):
             return np.mean(self.observations <= a)
         vf = np.frompyfunc(f, 1, 1)
-        return vf(x).astype(np.float)
+        return vf(x).astype(float)

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -48,4 +48,6 @@ class ECDF:
             Fraction of the sample less than x
 
         """
-        return np.mean(self.observations <= x)
+        f = lambda a, b: a <= b
+        vf = np.vectorize(f)
+        return np.mean(vf(self.observations, x))

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -51,4 +51,4 @@ class ECDF:
         def f(a):
             return np.mean(self.observations <= a)
         vf = np.frompyfunc(f, 1, 1)
-        return vf(x)
+        return vf(x).astype(np.float)

--- a/quantecon/ecdf.py
+++ b/quantecon/ecdf.py
@@ -48,6 +48,7 @@ class ECDF:
             Fraction of the sample less than x
 
         """
-        f = lambda a, b: a <= b
-        vf = np.vectorize(f)
-        return np.mean(vf(self.observations, x))
+        def f(a):
+            return np.mean(self.observations <= a)
+        vf = np.frompyfunc(f, 1, 1)
+        return vf(x)

--- a/quantecon/tests/test_ecdf.py
+++ b/quantecon/tests/test_ecdf.py
@@ -34,6 +34,10 @@ class TestECDF(unittest.TestCase):
     def test_vectorized(self):
         "ecdf: testing vectorized __call__ method"
         t = np.linspace(-1, 1, 100)
-        self.assertEqual(t.shape, self.ecdf(t).shape)
+        e = self.ecdf(t)
+        self.assertEqual(t.shape, e.shape)
+        self.assertEqual(e.dtype, float)
         t = np.linspace(-1, 1, 100).reshape(2, 2, 25)
-        self.assertEqual(t.shape, self.ecdf(t).shape)
+        e = self.ecdf(t)
+        self.assertEqual(t.shape, e.shape)
+        self.assertEqual(e.dtype, float)

--- a/quantecon/tests/test_ecdf.py
+++ b/quantecon/tests/test_ecdf.py
@@ -30,3 +30,10 @@ class TestECDF(unittest.TestCase):
         F_1 = self.ecdf(x)
         F_2 = self.ecdf(1.1 * x)
         self.assertGreaterEqual(F_2, F_1)
+
+    def test_vectorized(self):
+        "ecdf: testing vectorized __call__ method"
+        t = np.linspace(-1, 1, 100)
+        self.assertEqual(t.shape, self.ecdf(t).shape)
+        t = np.linspace(-1, 1, 100).reshape(2, 2, 25)
+        self.assertEqual(t.shape, self.ecdf(t).shape)


### PR DESCRIPTION
Closes #97 

cc @jstac 