### PR TITLE
MAINT, TST: Remove nose imports and use pytest testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U nose coverage numpy scipy pandas numba sympy ipython statsmodels flake8 pytest
         python setup.py install
-    - name: Run Tests
+    - name: Run Tests (nose)
       run: |
         flake8 --select F401, F405,E231 quantecon
         nosetests --with-coverage -a "!slow" --cover-package=quantecon
-    - name: Run Tests
+    - name: Run Tests (pytest)
       run: |
         pytest quantecon/game_theory
     - name: Coveralls Parallel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U nose coverage numpy scipy pandas numba sympy ipython statsmodels flake8
+        pip install -U nose coverage numpy scipy pandas numba sympy ipython statsmodels flake8 pytest
         python setup.py install
     - name: Run Tests
       run: |
         flake8 --select F401, F405,E231 quantecon
         nosetests --with-coverage -a "!slow" --cover-package=quantecon
+    - name: Run Tests
+      run: |
+        pytest quantecon/game_theory
     - name: Coveralls Parallel
       uses: AndreMiras/coveralls-python-action@develop
       if: runner.os == 'Linux'

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -1,15 +1,13 @@
 """
 Tests for lemke_howson.py
-
 """
 import numpy as np
-from numpy.testing import assert_allclose
-from nose.tools import eq_, raises
+from numpy.testing import assert_allclose, assert_, assert_raises
 from quantecon.game_theory import Player, NormalFormGame, lemke_howson
 
 
 class TestLemkeHowson():
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # From von Stengel 2007 in Algorithmic Game Theory
@@ -32,7 +30,7 @@ class TestLemkeHowson():
 
 
 class TestLemkeHowsonDegenerate():
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # From von Stengel 2007 in Algorithmic Game Theory
@@ -80,7 +78,7 @@ class TestLemkeHowsonDegenerate():
                 for action_computed, action in zip(NE_computed,
                                                    d['NEs_dict'][k]):
                     assert_allclose(action_computed, action)
-                eq_(res.converged, d['converged'])
+                assert_(res.converged == d['converged'])
 
 
 def test_lemke_howson_capping():
@@ -98,47 +96,34 @@ def test_lemke_howson_capping():
                                  capping=max_iter, full_output=True)
         for action0, action1 in zip(NE0, NE1):
             assert_allclose(action0, action1)
-        eq_(res0.init, res1.init)
+        assert_(res0.init == res1.init)
 
     init_pivot = 1
     max_iter = m+n
     NE, res = lemke_howson(g, init_pivot=init_pivot, max_iter=max_iter,
                            capping=1, full_output=True)
-    eq_(res.num_iter, max_iter)
-    eq_(res.init, init_pivot-1)
+    assert_(res.num_iter == max_iter)
+    assert_(res.init == init_pivot-1)
 
 
-@raises(TypeError)
 def test_lemke_howson_invalid_g():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
-    lemke_howson(bimatrix)
+    assert_raises(TypeError, lemke_howson, bimatrix)
 
 
-@raises(ValueError)
 def test_lemke_howson_invalid_init_pivot_integer():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
     g = NormalFormGame(bimatrix)
-    lemke_howson(g, -1)
+    assert_raises(ValueError, lemke_howson, g, -1)
 
 
-@raises(TypeError)
 def test_lemke_howson_invalid_init_pivot_float():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
     g = NormalFormGame(bimatrix)
-    lemke_howson(g, 1.0)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+    assert_raises(TypeError, lemke_howson, g, 1.0)

--- a/quantecon/game_theory/tests/test_mclennan_tourky.py
+++ b/quantecon/game_theory/tests/test_mclennan_tourky.py
@@ -1,10 +1,8 @@
 """
 Tests for mclennan_tourky.py
-
 """
 import numpy as np
-from numpy.testing import assert_array_equal
-from nose.tools import ok_, raises
+from numpy.testing import assert_array_equal, assert_raises, assert_
 from quantecon.game_theory import Player, NormalFormGame, mclennan_tourky
 from quantecon.game_theory.mclennan_tourky import (
      _best_response_selection, _flatten_action_profile, _is_epsilon_nash
@@ -12,7 +10,7 @@ from quantecon.game_theory.mclennan_tourky import (
 
 
 class TestMclennanTourky():
-    def setUp(self):
+    def setup(self):
         def anti_coordination(N, v):
             payoff_array = np.empty((2,)*N)
             payoff_array[0, :] = 1
@@ -48,37 +46,34 @@ class TestMclennanTourky():
     def test_convergence_default(self):
         for d in self.game_dicts:
             NE, res = mclennan_tourky(d['g'], full_output=True)
-            ok_(res.converged)
+            assert_(res.converged)
 
     def test_pure_nash(self):
         for d in self.game_dicts:
             init = (1,) + (0,)*(d['g'].N-1)
             NE, res = mclennan_tourky(d['g'], init=init, full_output=True)
-            ok_(res.num_iter==1)
+            assert_(res.num_iter==1)
 
 
 class TestMclennanTourkyInvalidInputs():
-    def setUp(self):
+    def setup(self):
             self.bimatrix = [[(3, 3), (3, 2)],
                              [(2, 2), (5, 6)],
                              [(0, 3), (6, 1)]]
             self.g = NormalFormGame(self.bimatrix)
 
-    @raises(TypeError)
     def test_mclennan_tourky_invalid_g(self):
-        mclennan_tourky(self.bimatrix)
+        assert_raises(TypeError, mclennan_tourky, self.bimatrix)
 
-    @raises(TypeError)
     def test_mclennan_tourky_invalid_init_type(self):
-        mclennan_tourky(self.g, 1)
+        assert_raises(TypeError, mclennan_tourky, self.g, 1)
 
-    @raises(ValueError)
     def test_mclennan_tourky_invalid_init_length(self):
-        mclennan_tourky(self.g, [1])
+        assert_raises(ValueError, mclennan_tourky, self.g, [1])
 
 
 class TestEpsilonNash():
-    def setUp(self):
+    def setup(self):
         def anti_coordination(N, v):
             payoff_array = np.empty((2,)*N)
             payoff_array[0, :] = 1
@@ -121,17 +116,17 @@ class TestEpsilonNash():
             NE, res = \
                 mclennan_tourky(d['g'], epsilon=d['epsilon'], full_output=True)
             for i in range(d['g'].N):
-                ok_(d['lb'] < NE[i][0] < d['ub'])
+                assert_(d['lb'] < NE[i][0] < d['ub'])
 
     def test_epsilon_nash_without_full_output(self):
         for d in self.game_dicts:
             NE = mclennan_tourky(d['g'], epsilon=d['epsilon'],
                                  full_output=False)
             for i in range(d['g'].N):
-                ok_(d['lb'] < NE[i][0] < d['ub'])
+                assert_(d['lb'] < NE[i][0] < d['ub'])
 
     def test_is_epsilon_nash_no_indptr(self):
-        ok_(_is_epsilon_nash([1., 0., 0., 1., 0.], self.g, 1e-5))
+        assert_(_is_epsilon_nash([1., 0., 0., 1., 0.], self.g, 1e-5))
 
 
 def test_flatten_action_profile():
@@ -151,13 +146,3 @@ def test_best_response_selection_no_indptr():
     expected_output = np.array([0., 1., 0., 0., 1.])
 
     assert_array_equal(test_obj, expected_output)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)

--- a/quantecon/game_theory/tests/test_mclennan_tourky.py
+++ b/quantecon/game_theory/tests/test_mclennan_tourky.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_raises, assert_
 from quantecon.game_theory import Player, NormalFormGame, mclennan_tourky
 from quantecon.game_theory.mclennan_tourky import (
-     _best_response_selection, _flatten_action_profile, _is_epsilon_nash
+    _best_response_selection, _flatten_action_profile, _is_epsilon_nash
 )
 
 
@@ -52,7 +52,7 @@ class TestMclennanTourky():
         for d in self.game_dicts:
             init = (1,) + (0,)*(d['g'].N-1)
             NE, res = mclennan_tourky(d['g'], init=init, full_output=True)
-            assert_(res.num_iter==1)
+            assert_(res.num_iter == 1)
 
 
 class TestMclennanTourkyInvalidInputs():

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -66,9 +66,9 @@ class TestPlayer_1opponent:
     def test_best_response_with_payoff_perturbation(self):
         """best_response with payoff_perturbation"""
         assert_(self.player.best_response([2/3, 1/3],
-                                      payoff_perturbation=[0, 0.1]) == 1)
+                payoff_perturbation=[0, 0.1]) == 1)
         assert_(self.player.best_response([2, 1],  # int
-                                      payoff_perturbation=[0, 0.1]) == 1)
+                payoff_perturbation=[0, 0.1]) == 1)
 
     def test_is_best_response_against_pure(self):
         assert_(self.player.is_best_response(0, 0))
@@ -79,7 +79,7 @@ class TestPlayer_1opponent:
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                assert_(self.player.is_dominated(action, method=method) == False)
+                assert_(not self.player.is_dominated(action, method=method))
 
     def test_dominated_actions(self):
         for method in LP_METHODS:
@@ -132,7 +132,7 @@ class TestPlayer_2opponents:
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                assert_(self.player.is_dominated(action, method=method) == False)
+                assert_(not self.player.is_dominated(action, method=method))
 
     def test_dominated_actions(self):
         for method in LP_METHODS:
@@ -154,9 +154,9 @@ def test_player_corner_cases():
     n, m = 3, 4
     player = Player(np.zeros((n, m)))
     for action in range(n):
-        assert_(player.is_best_response(action, [1/m]*m) == True)
+        assert_(player.is_best_response(action, [1/m]*m))
         for method in LP_METHODS:
-            assert_(player.is_dominated(action, method=method) == False)
+            assert_(not player.is_dominated(action, method=method))
 
     e = 1e-8 * 2
     player = Player([[-e, -e], [1, -1], [-1, 1]])
@@ -164,10 +164,10 @@ def test_player_corner_cases():
     assert_(player.is_best_response(action, [1/2, 1/2], tol=e))
     assert_(not player.is_best_response(action, [1/2, 1/2], tol=e/2))
     for method in LP_METHODS:
-        assert_(player.is_dominated(action, tol=2*e, method=method) == False)
+        assert_(not player.is_dominated(action, tol=2*e, method=method))
         assert_(player.dominated_actions(tol=2*e, method=method) == [])
 
-        assert_(player.is_dominated(action, tol=e/2, method=method) == True)
+        assert_(player.is_dominated(action, tol=e/2, method=method))
         assert_(player.dominated_actions(tol=e/2, method=method) == [action])
 
 
@@ -452,7 +452,7 @@ class TestPlayer_1action:
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                assert_(self.player.is_dominated(action, method=method) == False)
+                assert_(not self.player.is_dominated(action, method=method))
 
     def test_dominated_actions(self):
         for method in LP_METHODS:

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -1,10 +1,8 @@
 """
 Tests for normal_form_game.py
-
 """
 import numpy as np
-from numpy.testing import assert_array_equal
-from nose.tools import eq_, ok_, raises
+from numpy.testing import assert_array_equal, assert_, assert_raises
 
 from quantecon.game_theory import (
     Player, NormalFormGame, pure2mixed, best_response_2p
@@ -19,7 +17,7 @@ LP_METHODS = [None, 'simplex', 'interior-point', 'revised simplex']
 class TestPlayer_1opponent:
     """Test the methods of Player with one opponent player"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a Player instance"""
         coordination_game_matrix = [[4, 0], [3, 2]]
         self.player = Player(coordination_game_matrix)
@@ -37,10 +35,10 @@ class TestPlayer_1opponent:
             )
 
     def test_best_response_against_pure(self):
-        eq_(self.player.best_response(1), 1)
+        assert_(self.player.best_response(1) == 1)
 
     def test_best_response_against_mixed(self):
-        eq_(self.player.best_response([1/2, 1/2]), 1)
+        assert_(self.player.best_response([1/2, 1/2]) == 1)
 
     def test_best_response_list_when_tie(self):
         """best_response with tie_breaking=False"""
@@ -51,7 +49,7 @@ class TestPlayer_1opponent:
 
     def test_best_response_with_random_tie_breaking(self):
         """best_response with tie_breaking='random'"""
-        ok_(self.player.best_response([2/3, 1/3], tie_breaking='random')
+        assert_(self.player.best_response([2/3, 1/3], tie_breaking='random')
             in [0, 1])
 
         seed = 1234
@@ -59,41 +57,39 @@ class TestPlayer_1opponent:
                                         random_state=seed)
         br1 = self.player.best_response([2/3, 1/3], tie_breaking='random',
                                         random_state=seed)
-        eq_(br0, br1)
+        assert_(br0 == br1)
 
     def test_best_response_with_smallest_tie_breaking(self):
         """best_response with tie_breaking='smallest' (default)"""
-        eq_(self.player.best_response([2/3, 1/3]), 0)
+        assert_(self.player.best_response([2/3, 1/3]) == 0)
 
     def test_best_response_with_payoff_perturbation(self):
         """best_response with payoff_perturbation"""
-        eq_(self.player.best_response([2/3, 1/3],
-                                      payoff_perturbation=[0, 0.1]),
-            1)
-        eq_(self.player.best_response([2, 1],  # int
-                                      payoff_perturbation=[0, 0.1]),
-            1)
+        assert_(self.player.best_response([2/3, 1/3],
+                                      payoff_perturbation=[0, 0.1]) == 1)
+        assert_(self.player.best_response([2, 1],  # int
+                                      payoff_perturbation=[0, 0.1]) == 1)
 
     def test_is_best_response_against_pure(self):
-        ok_(self.player.is_best_response(0, 0))
+        assert_(self.player.is_best_response(0, 0))
 
     def test_is_best_response_against_mixed(self):
-        ok_(self.player.is_best_response([1/2, 1/2], [2/3, 1/3]))
+        assert_(self.player.is_best_response([1/2, 1/2], [2/3, 1/3]))
 
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                eq_(self.player.is_dominated(action, method=method), False)
+                assert_(self.player.is_dominated(action, method=method) == False)
 
     def test_dominated_actions(self):
         for method in LP_METHODS:
-            eq_(self.player.dominated_actions(method=method), [])
+            assert_(self.player.dominated_actions(method=method) == [])
 
 
 class TestPlayer_2opponents:
     """Test the methods of Player with two opponent players"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a Player instance"""
         payoffs_2opponents = [[[3, 6],
                                [4, 2]],
@@ -117,10 +113,10 @@ class TestPlayer_2opponents:
         assert_array_equal(self.player.payoff_vector((0, 1)), [6, 0])
 
     def test_is_best_response_against_pure(self):
-        ok_(not self.player.is_best_response(0, (1, 0)))
+        assert_(not self.player.is_best_response(0, (1, 0)))
 
     def test_best_response_against_pure(self):
-        eq_(self.player.best_response((1, 1)), 1)
+        assert_(self.player.best_response((1, 1)) == 1)
 
     def test_best_response_list_when_tie(self):
         """
@@ -136,11 +132,11 @@ class TestPlayer_2opponents:
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                eq_(self.player.is_dominated(action, method=method), False)
+                assert_(self.player.is_dominated(action, method=method) == False)
 
     def test_dominated_actions(self):
         for method in LP_METHODS:
-            eq_(self.player.dominated_actions(method=method), [])
+            assert_(self.player.dominated_actions(method=method) == [])
 
 
 def test_random_choice():
@@ -148,31 +144,31 @@ def test_random_choice():
     payoff_matrix = np.zeros((n, m))
     player = Player(payoff_matrix)
 
-    eq_(player.random_choice([0]), 0)
+    assert_(player.random_choice([0]) == 0)
 
     actions = list(range(player.num_actions))
-    ok_(player.random_choice() in actions)
+    assert_(player.random_choice() in actions)
 
 
 def test_player_corner_cases():
     n, m = 3, 4
     player = Player(np.zeros((n, m)))
     for action in range(n):
-        eq_(player.is_best_response(action, [1/m]*m), True)
+        assert_(player.is_best_response(action, [1/m]*m) == True)
         for method in LP_METHODS:
-            eq_(player.is_dominated(action, method=method), False)
+            assert_(player.is_dominated(action, method=method) == False)
 
     e = 1e-8 * 2
     player = Player([[-e, -e], [1, -1], [-1, 1]])
     action = 0
-    eq_(player.is_best_response(action, [1/2, 1/2], tol=e), True)
-    eq_(player.is_best_response(action, [1/2, 1/2], tol=e/2), False)
+    assert_(player.is_best_response(action, [1/2, 1/2], tol=e))
+    assert_(not player.is_best_response(action, [1/2, 1/2], tol=e/2))
     for method in LP_METHODS:
-        eq_(player.is_dominated(action, tol=2*e, method=method), False)
-        eq_(player.dominated_actions(tol=2*e, method=method), [])
+        assert_(player.is_dominated(action, tol=2*e, method=method) == False)
+        assert_(player.dominated_actions(tol=2*e, method=method) == [])
 
-        eq_(player.is_dominated(action, tol=e/2, method=method), True)
-        eq_(player.dominated_actions(tol=e/2, method=method), [action])
+        assert_(player.is_dominated(action, tol=e/2, method=method) == True)
+        assert_(player.dominated_actions(tol=e/2, method=method) == [action])
 
 
 # NormalFormGame #
@@ -180,7 +176,7 @@ def test_player_corner_cases():
 class TestNormalFormGame_Sym2p:
     """Test the methods of NormalFormGame with symmetric two players"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a NormalFormGame instance"""
         coordination_game_matrix = [[4, 0], [3, 2]]
         self.g = NormalFormGame(coordination_game_matrix)
@@ -189,16 +185,16 @@ class TestNormalFormGame_Sym2p:
         assert_array_equal(self.g[0, 1], [0, 3])
 
     def test_is_nash_pure(self):
-        ok_(self.g.is_nash((0, 0)))
+        assert_(self.g.is_nash((0, 0)))
 
     def test_is_nash_mixed(self):
-        ok_(self.g.is_nash(([2/3, 1/3], [2/3, 1/3])))
+        assert_(self.g.is_nash(([2/3, 1/3], [2/3, 1/3])))
 
 
 class TestNormalFormGame_Asym2p:
     """Test the methods of NormalFormGame with asymmetric two players"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a NormalFormGame instance"""
         self.BoS_bimatrix = np.array([[(3, 2), (1, 1)],
                                       [(0, 0), (2, 3)]])
@@ -221,10 +217,10 @@ class TestNormalFormGame_Asym2p:
             )
 
     def test_is_nash_pure(self):
-        ok_(not self.g.is_nash((1, 0)))
+        assert_(not self.g.is_nash((1, 0)))
 
     def test_is_nash_mixed(self):
-        ok_(self.g.is_nash(([3/4, 1/4], [1/4, 3/4])))
+        assert_(self.g.is_nash(([3/4, 1/4], [1/4, 3/4])))
 
     def test_payoff_arrays(self):
         assert_array_equal(
@@ -238,7 +234,7 @@ class TestNormalFormGame_Asym2p:
 class TestNormalFormGame_3p:
     """Test the methods of NormalFormGame with three players"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a NormalFormGame instance"""
         payoffs_2opponents = [[[3, 6],
                                [4, 2]],
@@ -262,18 +258,18 @@ class TestNormalFormGame_3p:
             )
 
     def test_is_nash_pure(self):
-        ok_(self.g.is_nash((0, 0, 0)))
-        ok_(not self.g.is_nash((0, 0, 1)))
+        assert_(self.g.is_nash((0, 0, 0)))
+        assert_(not self.g.is_nash((0, 0, 1)))
 
     def test_is_nash_mixed(self):
         p = (1 + np.sqrt(65)) / 16
-        ok_(self.g.is_nash(([1 - p, p], [1 - p, p], [1 - p, p])))
+        assert_(self.g.is_nash(([1 - p, p], [1 - p, p], [1 - p, p])))
 
 
 def test_normalformgame_input_action_sizes():
     g = NormalFormGame((2, 3, 4))
 
-    eq_(g.N, 3)  # Number of players
+    assert_(g.N == 3)  # Number of players
 
     assert_array_equal(
         g.players[0].payoff_array,
@@ -309,10 +305,10 @@ def test_normalformgame_setitem():
 def test_normalformgame_constant_payoffs():
     g = NormalFormGame((2, 2))
 
-    ok_(g.is_nash((0, 0)))
-    ok_(g.is_nash((0, 1)))
-    ok_(g.is_nash((1, 0)))
-    ok_(g.is_nash((1, 1)))
+    assert_(g.is_nash((0, 0)))
+    assert_(g.is_nash((0, 1)))
+    assert_(g.is_nash((1, 0)))
+    assert_(g.is_nash((1, 1)))
 
 
 def test_normalformgame_payoff_profile_array():
@@ -337,7 +333,7 @@ def test_normalformgame_payoff_profile_array_c_contiguous():
         np.arange(np.prod(shape)).reshape(shape)
     g = NormalFormGame(payoff_profile_array)
     for player in g.players:
-        ok_(player.payoff_array.flags['C_CONTIGUOUS'])
+        assert_(player.payoff_array.flags['C_CONTIGUOUS'])
 
 
 # Trivial cases with one player #
@@ -345,7 +341,7 @@ def test_normalformgame_payoff_profile_array_c_contiguous():
 class TestPlayer_0opponents:
     """Test for trivial Player with no opponent player"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a Player instance"""
         self.payoffs = [0, 1, -1]
         self.player = Player(self.payoffs)
@@ -370,39 +366,39 @@ class TestPlayer_0opponents:
 
     def test_is_best_response(self):
         """Trivial player: is_best_response"""
-        ok_(self.player.is_best_response(self.best_response_action, None))
+        assert_(self.player.is_best_response(self.best_response_action, None))
 
     def test_best_response(self):
         """Trivial player: best_response"""
-        eq_(self.player.best_response(None), self.best_response_action)
+        assert_(self.player.best_response(None) == self.best_response_action)
 
     def test_is_dominated(self):
         """Trivial player: is_dominated"""
         for action in range(self.player.num_actions):
-            eq_(self.player.is_dominated(action),
+            assert_(self.player.is_dominated(action) ==
                 (action in self.dominated_actions))
 
     def test_dominated_actions(self):
         """Trivial player: dominated_actions"""
-        eq_(self.player.dominated_actions(), self.dominated_actions)
+        assert_(self.player.dominated_actions() == self.dominated_actions)
 
 
 class TestNormalFormGame_1p:
     """Test for trivial NormalFormGame with a single player"""
 
-    def setUp(self):
+    def setup(self):
         """Setup a NormalFormGame instance"""
         data = [[0], [1], [1]]
         self.g = NormalFormGame(data)
 
     def test_construction(self):
         """Trivial game: construction"""
-        ok_(self.g.N == 1)
+        assert_(self.g.N == 1)
         assert_array_equal(self.g.players[0].payoff_array, [0, 1, 1])
 
     def test_getitem(self):
         """Trivial game: __getitem__"""
-        eq_(self.g[0], 0)
+        assert_(self.g[0] == 0)
 
     def test_delete_action(self):
         actions_to_delete = [1, 2]
@@ -417,18 +413,18 @@ class TestNormalFormGame_1p:
 
     def test_is_nash_pure(self):
         """Trivial game: is_nash with pure action"""
-        ok_(self.g.is_nash((1,)))
-        ok_(not self.g.is_nash((0,)))
+        assert_(self.g.is_nash((1,)))
+        assert_(not self.g.is_nash((0,)))
 
     def test_is_nash_mixed(self):
         """Trivial game: is_nash with mixed action"""
-        ok_(self.g.is_nash(([0, 1/2, 1/2],)))
+        assert_(self.g.is_nash(([0, 1/2, 1/2],)))
 
 
 def test_normalformgame_input_action_sizes_1p():
     g = NormalFormGame(2)
 
-    eq_(g.N, 1)  # Number of players
+    assert_(g.N == 1)  # Number of players
 
     assert_array_equal(
         g.players[0].payoff_array,
@@ -439,16 +435,16 @@ def test_normalformgame_input_action_sizes_1p():
 def test_normalformgame_setitem_1p():
     g = NormalFormGame(2)
 
-    eq_(g.N, 1)  # Number of players
+    assert_(g.N == 1)  # Number of players
 
     g[0] = 10  # Set payoff 10 for action 0
-    eq_(g.players[0].payoff_array[0], 10)
+    assert_(g.players[0].payoff_array[0] == 10)
 
 
 # Trivial cases with one action #
 
 class TestPlayer_1action:
-    def setUp(self):
+    def setup(self):
         """Setup a Player instance"""
         self.payoffs = [[0, 1]]
         self.player = Player(self.payoffs)
@@ -456,11 +452,11 @@ class TestPlayer_1action:
     def test_is_dominated(self):
         for action in range(self.player.num_actions):
             for method in LP_METHODS:
-                eq_(self.player.is_dominated(action, method=method), False)
+                assert_(self.player.is_dominated(action, method=method) == False)
 
     def test_dominated_actions(self):
         for method in LP_METHODS:
-            eq_(self.player.dominated_actions(method=method), [])
+            assert_(self.player.dominated_actions(method=method) == [])
 
 
 # Test __repr__ #
@@ -480,45 +476,38 @@ def test_player_repr():
 
 # Invalid inputs #
 
-@raises(ValueError)
 def test_player_zero_actions():
-    Player([[]])
+    assert_raises(ValueError, Player, [[]])
 
 
-@raises(ValueError)
 def test_normalformgame_invalid_input_players_shape_inconsistent():
     p0 = Player(np.zeros((2, 3)))
     p1 = Player(np.zeros((2, 3)))
-    NormalFormGame([p0, p1])
+    assert_raises(ValueError, NormalFormGame, [p0, p1])
 
 
-@raises(ValueError)
 def test_normalformgame_invalid_input_players_num_inconsistent():
     p0 = Player(np.zeros((2, 2, 2)))
     p1 = Player(np.zeros((2, 2, 2)))
-    NormalFormGame([p0, p1])
+    assert_raises(ValueError, NormalFormGame, [p0, p1])
 
 
-@raises(ValueError)
 def test_normalformgame_invalid_input_players_dtype_inconsistent():
     p0 = Player(np.zeros((2, 2), dtype=int))
     p1 = Player(np.zeros((2, 2), dtype=float))
-    NormalFormGame([p0, p1])
+    assert_raises(ValueError, NormalFormGame, [p0, p1])
 
 
-@raises(ValueError)
 def test_normalformgame_invalid_input_nosquare_matrix():
-    NormalFormGame(np.zeros((2, 3)))
+    assert_raises(ValueError, NormalFormGame, np.zeros((2, 3)))
 
 
-@raises(ValueError)
 def test_normalformgame_invalid_input_payoff_profiles():
-    NormalFormGame(np.zeros((2, 2, 1)))
+    assert_raises(ValueError, NormalFormGame, np.zeros((2, 2, 1)))
 
 
-@raises(ValueError)
 def test_normalformgame_zero_actions():
-    NormalFormGame((2, 0))
+    assert_raises(ValueError, NormalFormGame, (2, 0))
 
 
 # Utility functions #
@@ -551,14 +540,4 @@ def test_best_response_2p():
                                              test_case['brs_expected']):
             br_computed = \
                 best_response_2p(test_case['payoff_array'], mixed_action)
-            eq_(br_computed, br_expected)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+            assert_(br_computed == br_expected)

--- a/quantecon/game_theory/tests/test_pure_nash.py
+++ b/quantecon/game_theory/tests/test_pure_nash.py
@@ -5,12 +5,12 @@ Tests for pure_nash.py
 
 import numpy as np
 import itertools
-from nose.tools import eq_
+from numpy.testing import assert_
 from quantecon.game_theory import NormalFormGame, pure_nash_brute
 
 
 class TestPureNashBruteForce():
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # Matching Pennies game with no pure nash equilibrium
@@ -53,7 +53,7 @@ class TestPureNashBruteForce():
 
     def test_brute_force(self):
         for d in self.game_dicts:
-            eq_(sorted(pure_nash_brute(d['g'])), sorted(d['NEs']))
+            assert_(sorted(pure_nash_brute(d['g'])) == sorted(d['NEs']))
 
     def test_tol(self):
         # Prisoners' Dilemma game with one NE and one epsilon NE
@@ -67,14 +67,4 @@ class TestPureNashBruteForce():
 
         g = NormalFormGame(PD_bimatrix)
         for tol, answer in zip([0, epsilon], [NEs, epsilon_NEs]):
-            eq_(sorted(pure_nash_brute(g, tol=tol)), sorted(answer))
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+            assert_(sorted(pure_nash_brute(g, tol=tol)) == sorted(answer))

--- a/quantecon/game_theory/tests/test_random.py
+++ b/quantecon/game_theory/tests/test_random.py
@@ -3,9 +3,7 @@ Tests for game_theory/random.py
 
 """
 import numpy as np
-from numpy.testing import assert_allclose, assert_raises
-from nose.tools import eq_, ok_
-
+from numpy.testing import assert_allclose, assert_raises, assert_
 from quantecon.game_theory import (
     random_game, covariance_game, random_pure_actions, random_mixed_actions
 )
@@ -14,7 +12,7 @@ from quantecon.game_theory import (
 def test_random_game():
     nums_actions = (2, 3, 4)
     g = random_game(nums_actions)
-    eq_(g.nums_actions, nums_actions)
+    assert_(g.nums_actions == nums_actions)
 
 
 def test_covariance_game():
@@ -23,7 +21,7 @@ def test_covariance_game():
 
     rho = 0.5
     g = covariance_game(nums_actions, rho=rho)
-    eq_(g.nums_actions, nums_actions)
+    assert_(g.nums_actions == nums_actions)
 
     rho = 1
     g = covariance_game(nums_actions, rho=rho)
@@ -69,22 +67,12 @@ def test_random_pure_actions():
         random_pure_actions(nums_actions, seed) for i in range(2)
     ]
     for i in range(N):
-        ok_(action_profiles[0][i] < nums_actions[i])
-    eq_(action_profiles[0], action_profiles[1])
+        assert_(action_profiles[0][i] < nums_actions[i])
+    assert_(action_profiles[0] == action_profiles[1])
 
 
 def test_random_mixed_actions():
     nums_actions = (2, 3, 4)
     seed = 1234
     action_profile = random_mixed_actions(nums_actions, seed)
-    eq_(tuple([len(action) for action in action_profile]), nums_actions)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+    assert_(tuple([len(action) for action in action_profile]) == nums_actions)

--- a/quantecon/game_theory/tests/test_repeated_game.py
+++ b/quantecon/game_theory/tests/test_repeated_game.py
@@ -8,7 +8,7 @@ from quantecon.game_theory import NormalFormGame, RepeatedGame
 
 
 class TestAS():
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # Example from Abreu and Sannikov (2014)
@@ -47,12 +47,3 @@ class TestAS():
                 hull = rpg.equilibrium_payoffs(method=method,
                                                options={'u_init': d['u']})
                 assert_allclose(hull.points[hull.vertices], d['vertices'])
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)

--- a/quantecon/game_theory/tests/test_support_enumeration.py
+++ b/quantecon/game_theory/tests/test_support_enumeration.py
@@ -3,8 +3,7 @@ Tests for support_enumeration.py
 
 """
 import numpy as np
-from numpy.testing import assert_allclose
-from nose.tools import eq_, raises
+from numpy.testing import assert_allclose, assert_, assert_raises
 from quantecon.util import check_random_state
 from quantecon.game_theory import Player, NormalFormGame, support_enumeration
 
@@ -30,7 +29,7 @@ def random_skew_sym(n, m=None, random_state=None):
 
 
 class TestSupportEnumeration():
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # From von Stengel 2007 in Algorithmic Game Theory
@@ -56,7 +55,7 @@ class TestSupportEnumeration():
     def test_support_enumeration(self):
         for d in self.game_dicts:
             NEs_computed = support_enumeration(d['g'])
-            eq_(len(NEs_computed), len(d['NEs']))
+            assert_(len(NEs_computed) == len(d['NEs']))
             for actions_computed, actions in zip(NEs_computed, d['NEs']):
                 for action_computed, action in zip(actions_computed, actions):
                     assert_allclose(action_computed, action)
@@ -69,19 +68,8 @@ class TestSupportEnumeration():
         support_enumeration(g)
 
 
-@raises(TypeError)
 def test_support_enumeration_invalid_g():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
-    support_enumeration(bimatrix)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+    assert_raises(TypeError, support_enumeration, bimatrix)

--- a/quantecon/game_theory/tests/test_vertex_enumeration.py
+++ b/quantecon/game_theory/tests/test_vertex_enumeration.py
@@ -3,14 +3,14 @@ Tests for vertex_enumeration.py
 
 """
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
-from nose.tools import eq_, raises
+from numpy.testing import (assert_allclose, assert_array_equal, assert_,
+                           assert_raises)
 from quantecon.game_theory import NormalFormGame, vertex_enumeration
 from quantecon.game_theory.vertex_enumeration import _BestResponsePolytope
 
 
 class TestVertexEnumeration:
-    def setUp(self):
+    def setup(self):
         self.game_dicts = []
 
         # From von Stengel 2007 in Algorithmic Game Theory
@@ -36,7 +36,7 @@ class TestVertexEnumeration:
     def test_vertex_enumeration(self):
         for d in self.game_dicts:
             NEs_computed = vertex_enumeration(d['g'])
-            eq_(len(NEs_computed), len(d['NEs']))
+            assert_(len(NEs_computed) == len(d['NEs']))
             for NEs in (NEs_computed, d['NEs']):
                 NEs.sort(key=lambda x: (list(x[0]), list(x[1])))
             for actions_computed, actions in zip(NEs_computed, d['NEs']):
@@ -55,7 +55,7 @@ def test_vertex_enumeration_qhull_options():
                     ([2/3, 1/3, 0], [1/3, 2/3])]
     qhull_options = 'QJ'
     NEs_computed = vertex_enumeration(g, qhull_options=qhull_options)
-    eq_(len(NEs_computed), len(NEs_expected))
+    assert_(len(NEs_computed) == len(NEs_expected))
     for NEs in (NEs_computed, NEs_expected):
         NEs.sort(key=lambda x: (list(x[1]), list(x[0])))
     for actions_computed, actions in zip(NEs_computed, NEs_expected):
@@ -63,16 +63,15 @@ def test_vertex_enumeration_qhull_options():
             assert_allclose(action_computed, action, atol=1e-10)
 
 
-@raises(TypeError)
 def test_vertex_enumeration_invalid_g():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
-    vertex_enumeration(bimatrix)
+    assert_raises(TypeError, vertex_enumeration, bimatrix)
 
 
 class TestBestResponsePolytope:
-    def setUp(self):
+    def setup(self):
         # From von Stengel 2007 in Algorithmic Game Theory
         bimatrix = [[(3, 3), (3, 2)],
                     [(2, 2), (5, 6)],
@@ -123,20 +122,9 @@ class TestBestResponsePolytope:
         assert_allclose(vertices_computed, self.vertices_P, atol=1e-15)
 
 
-@raises(TypeError)
 def test_best_response_polytope_invalid_player_instance():
     bimatrix = [[(3, 3), (3, 2)],
                 [(2, 2), (5, 6)],
                 [(0, 3), (6, 1)]]
     g = NormalFormGame(bimatrix)
-    _BestResponsePolytope(g)
-
-
-if __name__ == '__main__':
-    import sys
-    import nose
-
-    argv = sys.argv[:]
-    argv.append('--verbose')
-    argv.append('--nocapture')
-    nose.main(argv=argv, defaultTest=__file__)
+    assert_raises(TypeError, _BestResponsePolytope, g)


### PR DESCRIPTION
This PR adds `pytest` testing support for `game_theory`. I will also add a CI job testing using `pytest` for `game_theory`.

Related issue #539 