### PR TITLE
TEST: Exclude windows-latest python-version 3.8

### DIFF
--- a/.github/workflows/conda_ci.yml
+++ b/.github/workflows/conda_ci.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.8, 3.9, '3.10']
+        exclude:
+          - os: windows-latest
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.8, 3.9, '3.10']
+        exclude:
+          - os: windows-latest
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I propose to exclude windows-latest python-version 3.8, where we often have a failure for `TestTicTacToc.test_timer`.