### PR TITLE
FIX: issue with publish via tags

### DIFF
--- a/.github/workflows/conda_ci.yml
+++ b/.github/workflows/conda_ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This should fix the issue with `tagged` releases and `automatic publishing to pypi`