### PR TITLE
[MAINT] TST: Rename `tearDown` to `teardown_method` (pytest fixes)

### DIFF
--- a/quantecon/markov/tests/test_approximation.py
+++ b/quantecon/markov/tests/test_approximation.py
@@ -21,7 +21,7 @@ class TestTauchen:
         mc = tauchen(self.rho, self.sigma_u, self.b, self.m, self.n)
         self.x, self.P = mc.state_values, mc.P
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.x
         del self.P
 
@@ -63,7 +63,7 @@ class TestRouwenhorst:
         mc = rouwenhorst(self.n, self.ybar, self.sigma, self.rho)
         self.x, self.P = mc.state_values, mc.P
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.x
         del self.P
 

--- a/quantecon/tests/test_arma.py
+++ b/quantecon/tests/test_arma.py
@@ -18,7 +18,7 @@ class TestARMA():
 
         self.lp = ARMA(phi, theta, sigma)
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.lp
 
     def test_simulate(self):

--- a/quantecon/tests/test_dle.py
+++ b/quantecon/tests/test_dle.py
@@ -41,7 +41,7 @@ class TestDLE:
 
         self.dle = DLE(information, technology, preferences)
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.dle
 
     def test_transformation_Q(self):

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -27,7 +27,7 @@ class TestKalman:
         self.methods = ['doubling', 'qz']
 
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.kf
 
 

--- a/quantecon/tests/test_lqcontrol.py
+++ b/quantecon/tests/test_lqcontrol.py
@@ -33,7 +33,7 @@ class TestLQControl:
 
         self.methods = ['doubling', 'qz']
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.lq_scalar
         del self.lq_mat
 
@@ -137,7 +137,7 @@ class TestLQMarkov:
         self.lq_markov_mat2 = LQMarkov(Π, Qs, Rs, As, Bs,
                                        Cs=Cs, Ns=Ns, beta=1.05)
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.lq_markov_scalar
         del self.lq_markov_mat1
         del self.lq_markov_mat2

--- a/quantecon/tests/test_lss.py
+++ b/quantecon/tests/test_lss.py
@@ -30,7 +30,7 @@ class TestLinearStateSpace:
 
         self.ss2 = LinearStateSpace(A, C, G, mu_0=mu_0)
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.ss1
         del self.ss2
 

--- a/quantecon/tests/test_rank_nullspace.py
+++ b/quantecon/tests/test_rank_nullspace.py
@@ -14,7 +14,7 @@ class TestRankNullspace:
         self.A2 = np.array([[1., 0, 0], [0., 1., 0], [1., 1., 0.]])
         self.A3 = np.zeros((3, 3))
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.A1
         del self.A2
         del self.A3

--- a/quantecon/tests/test_robustlq.py
+++ b/quantecon/tests/test_robustlq.py
@@ -49,7 +49,7 @@ class TestRBLQControl:
         self.lq_test = LQ(Q, R, A, B, C, beta=beta)
         self.methods = ['doubling', 'qz']
 
-    def tearDown(self):
+    def teardown_method(self):
         del self.rblq_test
         del self.rblq_test_pf
 

--- a/quantecon/util/tests/test_notebooks.py
+++ b/quantecon/util/tests/test_notebooks.py
@@ -37,5 +37,5 @@ class TestNotebookUtils:
             files=FILES, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDER)  #Second should skip
         assert(False in status)
 
-    def tearDown(self):
+    def teardown_method(self):
         os.remove("test_file.md")


### PR DESCRIPTION
docs: [teardown_method](https://docs.pytest.org/en/6.2.x/xunit_setup.html#method-and-function-level-setup-teardown)