### PR TITLE
DOCS: Remove "version" as it was deleted

### DIFF
--- a/docs/qe_apidoc.py
+++ b/docs/qe_apidoc.py
@@ -237,7 +237,6 @@ def model_tool():
     tool_files = glob("../quantecon/[a-z0-9]*.py")
     tools = list(map(lambda x: x.split('/')[-1][:-3], tool_files))
     # Alphabetize
-    tools.remove("version")
     tools.sort()
 
     # list file names of utilities


### PR DESCRIPTION
Ref: #606 

Fixes the following error in docs building:
```
Traceback (most recent call last):
  File "/Users/thebigbool/repos/QuantEcon.py/docs/qe_apidoc.py", line 341, in <module>
    model_tool()
  File "/Users/thebigbool/repos/QuantEcon.py/docs/qe_apidoc.py", line 240, in model_tool
    tools.remove("version")
ValueError: list.remove(x): x not in list
```