### PR TITLE
ENH: check_random_state: Accept `np.random.Generator`

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -2,7 +2,7 @@ sphinx
 ipython
 numpydoc
 numba>=0.38
-numpy>=1.2
+numpy>=1.17
 sympy
 scipy>=1.0
 requests

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -4,6 +4,6 @@ numpydoc
 numba>=0.38
 numpy>=1.17
 sympy
-scipy>=1.0
+scipy>=1.5
 requests
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
     'numba',
-    'numpy',
+    'numpy>=1.17.0',
     'requests',
     'scipy>=1.0.0',
     'sympy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     'numba',
     'numpy>=1.17.0',
     'requests',
-    'scipy>=1.0.0',
+    'scipy>=1.5.0',
     'sympy',
 ]
 

--- a/quantecon/arma.py
+++ b/quantecon/arma.py
@@ -236,11 +236,11 @@ class ARMA:
         ts_length : scalar(int), optional(default=90)
             Number of periods to simulate for
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------

--- a/quantecon/discrete_rv.py
+++ b/quantecon/discrete_rv.py
@@ -65,11 +65,11 @@ class DiscreteRV:
         k : scalar(int), optional
             Number of draws to be returned
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------

--- a/quantecon/game_theory/brd.py
+++ b/quantecon/game_theory/brd.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .normal_form_game import Player
-from ..util import check_random_state
+from ..util import check_random_state, rng_integers
 from .random import random_pure_actions
 
 
@@ -112,7 +112,7 @@ class BRD:
 
         out = np.empty((ts_length, self.num_actions), dtype=int)
         random_state = check_random_state(random_state)
-        player_ind_seq = random_state.randint(self.N, size=ts_length)
+        player_ind_seq = rng_integers(random_state, self.N, size=ts_length)
         action_dist = np.asarray(init_action_dist)
         for t in range(ts_length):
             out[t, :] = action_dist[:]

--- a/quantecon/game_theory/game_generators/bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/bimatrix_generators.py
@@ -129,11 +129,11 @@ def blotto_game(h, t, rho, mu=0, random_state=None):
         [-1, 1].
     mu : scalar(float), optional(default=0)
         Mean of the players' values of each hill.
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -225,11 +225,11 @@ def ranking_game(n, steps=10, random_state=None):
         the costs are multiples of `1/(n*steps)`, where the cost of
         effort level `0` is 0, and the maximum possible cost of effort
         level `n-1` is less than or equal to 1.
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -415,11 +415,11 @@ def tournament_game(n, k, random_state=None):
         Number of nodes in the tournament graph.
     k : scalar(int)
         Size of subsets of nodes in the tournament graph.
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -548,11 +548,11 @@ def unit_vector_game(n, avoid_pure_nash=False, random_state=None):
         If True, player 0's payoffs will be placed in order to avoid
         pure Nash equilibria. (If necessary, the payoffs for player 1
         are redrawn so as not to have a dominant action.)
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/game_theory/game_generators/bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/bimatrix_generators.py
@@ -94,7 +94,7 @@ import numpy as np
 import scipy.special
 from numba import jit
 from ..normal_form_game import Player, NormalFormGame
-from ...util import check_random_state
+from ...util import check_random_state, rng_integers
 from ...gridtools import simplex_grid
 from ...graph_tools import random_tournament_graph
 from ...util.combinatorics import next_k_array, k_array_rank_jit
@@ -255,11 +255,11 @@ def ranking_game(n, steps=10, random_state=None):
     payoff_arrays = tuple(np.empty((n, n)) for i in range(2))
     random_state = check_random_state(random_state)
 
-    scores = random_state.randint(1, steps+1, size=(2, n))
+    scores = rng_integers(random_state, 1, steps+1, size=(2, n))
     scores.cumsum(axis=1, out=scores)
 
     costs = np.empty((2, n-1))
-    costs[:] = random_state.randint(1, steps+1, size=(2, n-1))
+    costs[:] = rng_integers(random_state, 1, steps+1, size=(2, n-1))
     costs.cumsum(axis=1, out=costs)
     costs[:] /= (n * steps)
 
@@ -593,7 +593,7 @@ def unit_vector_game(n, avoid_pure_nash=False, random_state=None):
     payoff_arrays = (np.zeros((n, n)), random_state.random((n, n)))
 
     if not avoid_pure_nash:
-        ones_ind = random_state.randint(n, size=n)
+        ones_ind = rng_integers(random_state, n, size=n)
         payoff_arrays[0][ones_ind, np.arange(n)] = 1
     else:
         if n == 1:
@@ -609,9 +609,9 @@ def unit_vector_game(n, avoid_pure_nash=False, random_state=None):
             is_suboptimal.sum(axis=1, out=nums_suboptimal)
 
         for i in range(n):
-            one_ind = random_state.randint(n)
+            one_ind = rng_integers(random_state, n)
             while not is_suboptimal[i, one_ind]:
-                one_ind = random_state.randint(n)
+                one_ind = rng_integers(random_state, n)
             payoff_arrays[0][one_ind, i] = 1
 
     g = NormalFormGame(

--- a/quantecon/game_theory/game_generators/tests/test_bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/tests/test_bimatrix_generators.py
@@ -32,9 +32,12 @@ class TestBlottoGame:
         seed = 0
         h, t = 3, 4
         rho = -0.5
-        g0 = blotto_game(h, t, rho, random_state=seed)
-        g1 = blotto_game(h, t, rho, random_state=seed)
-        assert_array_equal(g1.payoff_profile_array, g0.payoff_profile_array)
+        for gen in [lambda x: x, np.random.default_rng]:
+            gs = [
+                blotto_game(h, t, rho, random_state=gen(seed))
+                for i in range(2)
+            ]
+            assert_array_equal(*[g.payoff_profile_array for g in gs])
 
 
 class TestRankingGame:
@@ -59,9 +62,9 @@ class TestRankingGame:
     def test_seed(self):
         seed = 0
         n = 100
-        g0 = ranking_game(n, random_state=seed)
-        g1 = ranking_game(n, random_state=seed)
-        assert_array_equal(g1.payoff_profile_array, g0.payoff_profile_array)
+        for gen in [lambda x: x, np.random.default_rng]:
+            gs = [ranking_game(n, random_state=gen(seed)) for i in range(2)]
+            assert_array_equal(*[g.payoff_profile_array for g in gs])
 
 
 def test_sgc_game():
@@ -106,9 +109,12 @@ class TestTournamentGame:
 
     def test_seed(self):
         seed = 0
-        g0 = tournament_game(self.n, self.k, random_state=seed)
-        g1 = tournament_game(self.n, self.k, random_state=seed)
-        assert_array_equal(g1.payoff_profile_array, g0.payoff_profile_array)
+        for gen in [lambda x: x, np.random.default_rng]:
+            gs = [
+                tournament_game(self.n, self.k, random_state=gen(seed))
+                for i in range(2)
+            ]
+            assert_array_equal(*[g.payoff_profile_array for g in gs])
 
     def test_raises_value_error_too_large_inputs(self):
         n, k = 100, 50
@@ -135,9 +141,11 @@ class TestUnitVectorGame:
     def test_seed(self):
         seed = 0
         n = 100
-        g0 = unit_vector_game(n, random_state=seed)
-        g1 = unit_vector_game(n, random_state=seed)
-        assert_array_equal(g1.payoff_profile_array, g0.payoff_profile_array)
+        for gen in [lambda x: x, np.random.default_rng]:
+            gs = [
+                unit_vector_game(n, random_state=gen(seed)) for i in range(2)
+            ]
+            assert_array_equal(*[g.payoff_profile_array for g in gs])
 
     def test_redraw(self):
         seed = 1

--- a/quantecon/game_theory/localint.py
+++ b/quantecon/game_theory/localint.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numbers
 from scipy import sparse
-from ..util import check_random_state
+from ..util import check_random_state, rng_integers
 from .random import random_pure_actions
 from .normal_form_game import Player
 
@@ -112,7 +112,8 @@ class LocalInteraction:
         elif revision == 'asynchronous':
             if player_ind_seq is None:
                 random_state = check_random_state(random_state)
-                player_ind_seq = random_state.randint(self.N, size=num_reps)
+                player_ind_seq = rng_integers(random_state, self.N,
+                                              size=num_reps)
             elif isinstance(player_ind_seq, numbers.Integral):
                 player_ind_seq = [player_ind_seq]
         else:
@@ -176,7 +177,8 @@ class LocalInteraction:
         elif revision == 'asynchronous':
             if player_ind_seq is None:
                 random_state = check_random_state(random_state)
-                player_ind_seq = random_state.randint(self.N, size=ts_length)
+                player_ind_seq = rng_integers(random_state, self.N,
+                                              size=ts_length)
         else:
             raise ValueError(
                             "revision must be `simultaneous` or `asynchronous`"

--- a/quantecon/game_theory/logitdyn.py
+++ b/quantecon/game_theory/logitdyn.py
@@ -92,7 +92,7 @@ class LogitDynamics:
         num_reps : scalar(int), optional(default=1)
             The number of iterations.
 
-        random_state : np.random.RandomState, optional(default=None)
+        random_state : int or np.random.RandomState/Generator, optional
             Random number generator used.
 
         Returns
@@ -134,7 +134,7 @@ class LogitDynamics:
             The action profile in the initial period. If None, selected
             randomly.
 
-        random_state : np.random.RandomState, optional(default=None)
+        random_state : int or np.random.RandomState/Generator, optional
             Random number generator used.
 
         Returns

--- a/quantecon/game_theory/logitdyn.py
+++ b/quantecon/game_theory/logitdyn.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numbers
 from .normal_form_game import NormalFormGame
-from ..util import check_random_state
+from ..util import check_random_state, rng_integers
 from .random import random_pure_actions
 
 
@@ -109,7 +109,7 @@ class LogitDynamics:
 
         if player_ind_seq is None:
             random_state = check_random_state(random_state)
-            player_ind_seq = random_state.randint(self.N, size=num_reps)
+            player_ind_seq = rng_integers(random_state, self.N, size=num_reps)
 
         if isinstance(player_ind_seq, numbers.Integral):
             player_ind_seq = [player_ind_seq]
@@ -150,7 +150,7 @@ class LogitDynamics:
 
         out = np.empty((ts_length, self.N), dtype=int)
         random_state = check_random_state(random_state)
-        player_ind_seq = random_state.randint(self.N, size=ts_length)
+        player_ind_seq = rng_integers(random_state, self.N, size=ts_length)
 
         for t, player_ind in enumerate(player_ind_seq):
             out[t, :] = actions[:]

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -130,7 +130,7 @@ import numbers
 import numpy as np
 from numba import jit
 
-from ..util import check_random_state
+from ..util import check_random_state, rng_integers
 
 
 class Player:
@@ -412,7 +412,7 @@ class Player:
         if n == 1:
             idx = 0
         else:
-            idx = random_state.randint(n)
+            idx = rng_integers(random_state, n)
 
         if actions is not None:
             return actions[idx]

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -339,11 +339,12 @@ class Player:
             Tolerance level used in determining best responses. If None,
             default to the value of the `tol` attribute.
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to
-            set the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState
-            is used. Relevant only when tie_breaking='random'.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used. Relevant only when
+            tie_breaking='random'.
 
         Returns
         -------
@@ -388,11 +389,11 @@ class Player:
         actions : array_like(int), optional(default=None)
             An array of integers representing pure actions.
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to
-            set the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState
-            is used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -20,11 +20,11 @@ def random_game(nums_actions, random_state=None):
     nums_actions : tuple(int)
         Tuple of the numbers of actions, one for each player.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -60,11 +60,11 @@ def covariance_game(nums_actions, rho, random_state=None):
         Covariance of a pair of payoff values. Must be in [-1/(N-1), 1],
         where N is the number of players.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -105,11 +105,11 @@ def random_pure_actions(nums_actions, random_state=None):
     nums_actions : tuple(int)
         Tuple of the numbers of actions, one for each player.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -133,7 +133,7 @@ def _random_mixed_actions(out, random_state):
     out : tuple(ndarray(float, ndim=1))
         Tuple of 1d ndarrays, to be modified in place.
 
-    random_state : np.random.RandomState
+    random_state : np.random.RandomState or np.random.Generator
 
     Return
     ------
@@ -159,11 +159,11 @@ def random_mixed_actions(nums_actions, random_state=None):
     nums_actions : tuple(int)
         Tuple of the numbers of actions, one for each player.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -6,7 +6,7 @@ Generate random NormalFormGame instances.
 import numpy as np
 
 from .normal_form_game import Player, NormalFormGame
-from ..util import check_random_state
+from ..util import check_random_state, rng_integers
 from ..random.utilities import _probvec_cpu
 
 
@@ -119,7 +119,7 @@ def random_pure_actions(nums_actions, random_state=None):
     """
     random_state = check_random_state(random_state)
     action_profile = tuple(
-        [random_state.randint(num_actions) for num_actions in nums_actions]
+        [rng_integers(random_state, num_actions) for num_actions in nums_actions]
     )
     return action_profile
 

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -30,6 +30,16 @@ def random_game(nums_actions, random_state=None):
     -------
     g : NormalFormGame
 
+    Examples
+    --------
+    >>> rng = np.random.default_rng(12345)
+    >>> g = random_game((3, 2), random_state=rng)
+    >>> print(g)
+    2-player NormalFormGame with payoff profile array:
+    [[[0.22733602, 0.59830875],  [0.31675834, 0.94180287]],
+     [[0.79736546, 0.18673419],  [0.67625467, 0.24824571]],
+     [[0.39110955, 0.67275604],  [0.33281393, 0.94888115]]]
+
     """
     N = len(nums_actions)
     if N == 0:
@@ -69,6 +79,16 @@ def covariance_game(nums_actions, rho, random_state=None):
     Returns
     -------
     g : NormalFormGame
+
+    Examples
+    --------
+    >>> rng = np.random.default_rng(12345)
+    >>> g = covariance_game((3, 2), rho=-0.7, random_state=rng)
+    >>> print(g)
+    2-player NormalFormGame with payoff profile array:
+    [[[ 1.80214175, -0.8232619 ],  [ 0.7023331 , -0.90308782]],
+     [[-0.2174803 , -0.35640649],  [ 1.51235766, -1.00972746]],
+     [[-1.08921974, -0.42346148],  [-1.78910753,  2.53930201]]]
 
     References
     ----------

--- a/quantecon/game_theory/tests/test_brd.py
+++ b/quantecon/game_theory/tests/test_brd.py
@@ -30,9 +30,9 @@ class TestBRD:
             )
 
     def test_time_series_2(self):
-        seed = 1234
+        seed = 329478856717593533176523622896549543480
         x = [self.brd.time_series(ts_length=3, init_action_dist=[2, 2],
-                                  random_state=np.random.RandomState(seed))
+                                  random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_equal(x[0], x[1])
 
@@ -47,9 +47,9 @@ class TestKMR:
         self.kmr = KMR(payoff_matrix, self.N)
 
     def test_time_series(self):
-        seed = 1234
+        seed = 21519527815966711149598801341951879349
         x = [self.kmr.time_series(ts_length=3, init_action_dist=[2, 2],
-                                  random_state=np.random.RandomState(seed))
+                                  random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_equal(x[0], x[1])
 
@@ -64,8 +64,8 @@ class TestSamplingBRD:
         self.sbrd = SamplingBRD(payoff_matrix, self.N)
 
     def test_time_series(self):
-        seed = 1234
+        seed = 205165126657120054758393970887343077472
         x = [self.sbrd.time_series(ts_length=3, init_action_dist=[2, 2],
-                                   random_state=np.random.RandomState(seed))
+                                   random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_equal(x[0], x[1])

--- a/quantecon/game_theory/tests/test_fictplay.py
+++ b/quantecon/game_theory/tests/test_fictplay.py
@@ -65,16 +65,16 @@ class TestStochasticFictitiosuPlayDecreaingGain:
                                            distribution=distribution)
 
     def test_play(self):
-        seed = 1234
+        seed = 272733541340907175684079858751241831341
         x = [self.fp.play(actions=(0, 0),
-                          random_state=np.random.RandomState(seed))
+                          random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_almost_equal(x[0], x[1])
 
     def test_time_series(self):
-        seed = 1234
+        seed = 226177486389088886197048956835604946950
         x = [self.fp.time_series(ts_length=3, init_actions=(0, 0),
-                                 random_state=np.random.RandomState(seed))
+                                 random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_almost_equal(x[0][0], x[1][0])
         assert_array_almost_equal(x[0][1], x[1][1])
@@ -90,16 +90,16 @@ class TestStochasticFictitiosuPlayConstantGain:
                                            distribution=distribution)
 
     def test_play(self):
-        seed = 1234
+        seed = 271001177347704493622442691590340912076
         x = [self.fp.play(actions=(0, 0),
-                          random_state=np.random.RandomState(seed))
+                          random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_almost_equal(x[0], x[1])
 
     def test_time_series(self):
-        seed = 1234
+        seed = 143773081180220547556482766921740826832
         x = [self.fp.time_series(ts_length=3, init_actions=(0, 0),
-                                 random_state=np.random.RandomState(seed))
+                                 random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_almost_equal(x[0][0], x[1][0])
         assert_array_almost_equal(x[0][1], x[1][1])

--- a/quantecon/game_theory/tests/test_localint.py
+++ b/quantecon/game_theory/tests/test_localint.py
@@ -35,12 +35,12 @@ class TestLocalInteraction:
                                                actions=init_actions), x)
 
     def test_time_series_asynchronous_revision(self):
-        seed = 1234
+        seed = 21388225457580135037104913043871211454
         init_actions = (0, 0, 1)
         x = [self.li.time_series(ts_length=3,
                                  revision='asynchronous',
                                  actions=init_actions,
-                                 random_state=np.random.RandomState(seed))
+                                 random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_equal(x[0], x[1])
 

--- a/quantecon/game_theory/tests/test_logitdyn.py
+++ b/quantecon/game_theory/tests/test_logitdyn.py
@@ -23,16 +23,16 @@ class TestLogitDynamics:
         self.ld = LogitDynamics(data, beta=beta)
 
     def test_play(self):
-        seed = 1234
+        seed = 76240103339929371127372784081282227092
         x = [self.ld.play(init_actions=(0, 0),
-                          random_state=np.random.RandomState(seed))
+                          random_state=np.random.default_rng(seed))
              for i in range(2)]
         assert_array_equal(x[0], x[1])
 
     def test_time_series(self):
-        seed = 1234
+        seed = 165570719993771384215214311194249493239
         series = [self.ld.time_series(ts_length=10, init_actions=(0, 0),
-                                      random_state=np.random.RandomState(seed))
+                                      random_state=np.random.default_rng(seed))
                   for i in range(2)]
         assert_array_equal(series[0], series[1])
 

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -53,11 +53,21 @@ class TestPlayer_1opponent:
                 in [0, 1])
 
         seed = 1234
-        br0 = self.player.best_response([2/3, 1/3], tie_breaking='random',
-                                        random_state=seed)
-        br1 = self.player.best_response([2/3, 1/3], tie_breaking='random',
-                                        random_state=seed)
-        assert_(br0 == br1)
+        brs = [
+            self.player.best_response([2/3, 1/3], tie_breaking='random',
+                                      random_state=seed)
+            for i in range(2)
+        ]
+        assert_(brs[0] == brs[1])
+
+        # Generate seed by np.random.SeedSequence().entropy
+        seed = 189001345436880673361166627406341705095
+        brs = [
+            self.player.best_response([2/3, 1/3], tie_breaking='random',
+                                      random_state=np.random.default_rng(seed))
+            for i in range(2)
+        ]
+        assert_(brs[0] == brs[1])
 
     def test_best_response_with_smallest_tie_breaking(self):
         """best_response with tie_breaking='smallest' (default)"""

--- a/quantecon/graph_tools.py
+++ b/quantecon/graph_tools.py
@@ -381,11 +381,11 @@ def random_tournament_graph(n, random_state=None):
     n : scalar(int)
         Number of nodes.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/lqcontrol.py
+++ b/quantecon/lqcontrol.py
@@ -274,11 +274,11 @@ class LQ:
             equation, str in {'doubling', 'qz'}. Only relevant when the
             `T` attribute is `None` (i.e., the horizon is infinite).
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------
@@ -560,11 +560,11 @@ class LQMarkov:
         ts_length : scalar(int), optional(default=None)
             Length of the simulation. If None, T is set to be 100
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------

--- a/quantecon/lqnash.py
+++ b/quantecon/lqnash.py
@@ -63,11 +63,11 @@ def nnash(A, B1, B2, R1, R2, Q1, Q2, S1, S2, W1, W2, M1, M2,
         This is the tolerance level for convergence
     max_iter : scalar(int), optional(default=1000)
         This is the maximum number of iteratiosn allowed
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/lss.py
+++ b/quantecon/lss.py
@@ -169,11 +169,11 @@ class LinearStateSpace:
         ----------
         ts_length : scalar(int), optional(default=100)
             The length of the simulation
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------
@@ -211,11 +211,11 @@ class LinearStateSpace:
             The period that we want to replicate values for
         num_reps : scalar(int), optional(default=100)
             The number of replications that we want
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to set
-            the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState is
-            used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -87,7 +87,7 @@ from numba import jit
 
 from .gth_solve import gth_solve
 from ..graph_tools import DiGraph
-from ..util import searchsorted, check_random_state
+from ..util import searchsorted, check_random_state, rng_integers
 
 
 class MarkovChain:
@@ -492,7 +492,7 @@ class MarkovChain:
                 dim = 2
                 k = num_reps
             if init is None:
-                init_states = random_state.randint(self.n, size=k)
+                init_states = rng_integers(random_state, self.n, size=k)
             elif isinstance(init, numbers.Integral):
                 # Check init is in the state space
                 if init >= self.n or init < -self.n:

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -455,11 +455,11 @@ class MarkovChain:
         num_reps : scalar(int), optional(default=None)
             Number of repetitions of simulation.
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to
-            set the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState
-            is used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------
@@ -542,11 +542,11 @@ class MarkovChain:
         num_reps : scalar(int), optional(default=None)
             Number of repetitions of simulation.
 
-        random_state : int or np.random.RandomState, optional
-            Random seed (integer) or np.random.RandomState instance to
-            set the initial state of the random number generator for
-            reproducibility. If None, a randomly initialized RandomState
-            is used.
+        random_state : int or np.random.RandomState/Generator, optional
+            Random seed (integer) or np.random.RandomState or Generator
+            instance to set the initial state of the random number
+            generator for reproducibility. If None, a randomly
+            initialized RandomState is used.
 
         Returns
         -------
@@ -687,11 +687,11 @@ def mc_sample_path(P, init=0, sample_size=1000, random_state=None):
     sample_size : scalar(int), optional(default=1000)
         The length of the sample path.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/markov/random.py
+++ b/quantecon/markov/random.py
@@ -30,11 +30,11 @@ def random_markov_chain(n, k=None, sparse=False, random_state=None):
         Whether to store the transition probability matrix in sparse
         matrix form.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -82,11 +82,11 @@ def random_stochastic_matrix(n, k=None, sparse=False, format='csr',
         Sparse matrix format, str in {'bsr', 'csr', 'csc', 'coo', 'lil',
         'dia', 'dok'}. Relevant only when sparse=True.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------
@@ -176,11 +176,11 @@ def random_discrete_dp(num_states, num_actions, beta=None,
         Whether to represent the data in the state-action pairs
         formulation. (If `sparse=True`, automatically set `True`.)
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -113,11 +113,12 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     equidist_pp : array_like, optional(default=None)
         TODO: I don't know what this does
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number
+        generator for reproducibility. If None, a randomly
+        initialized RandomState is used. Relevant only when setting
+        `kind='R'`.
 
     Returns
     -------
@@ -469,7 +470,7 @@ def qnwunif(n, a, b):
     return nodes, weights
 
 
-def quadrect(f, n, a, b, kind='lege', *args, **kwargs):
+def quadrect(f, n, a, b, kind='lege', random_state=None, *args, **kwargs):
     """
     Integrate the d-dimensional function f on a rectangle with lower and
     upper bound for dimension i defined by a[i] and b[i], respectively;
@@ -510,6 +511,12 @@ def quadrect(f, n, a, b, kind='lege', *args, **kwargs):
         H    - Haber  equidistributed sequence
         R    - Monte Carlo
 
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used. Relevant only when setting `kind='R'`.
+
     *args, **kwargs :
         Other arguments passed to the function f
 
@@ -538,7 +545,7 @@ def quadrect(f, n, a, b, kind='lege', *args, **kwargs):
     elif kind.lower() == "simp":
         nodes, weights = qnwsimp(n, a, b)
     else:
-        nodes, weights = qnwequi(n, a, b, kind)
+        nodes, weights = qnwequi(n, a, b, kind, random_state=random_state)
 
     out = weights.dot(f(nodes, *args, **kwargs))
     return out

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -23,11 +23,11 @@ def probvec(m, k, random_state=None, parallel=True):
     k : scalar(int)
         Dimension of each probability vectors.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     parallel : bool(default=True)
         Whether to use multi-core CPU (parallel=True) or single-threaded
@@ -113,11 +113,11 @@ def sample_without_replacement(n, k, num_trials=None, random_state=None):
     num_trials : scalar(int), optional(default=None)
         Number of trials.
 
-    random_state : int or np.random.RandomState, optional
-        Random seed (integer) or np.random.RandomState instance to set
-        the initial state of the random number generator for
-        reproducibility. If None, a randomly initialized RandomState is
-        used.
+    random_state : int or np.random.RandomState/Generator, optional
+        Random seed (integer) or np.random.RandomState or Generator
+        instance to set the initial state of the random number generator
+        for reproducibility. If None, a randomly initialized RandomState
+        is used.
 
     Returns
     -------

--- a/quantecon/tests/test_inequality.py
+++ b/quantecon/tests/test_inequality.py
@@ -103,12 +103,12 @@ def test_rank_size():
     of the size of the distribution.
     """
 
-    np.random.seed(15)
+    rng = np.random.default_rng(15)
     sample_size = 10000
     c = 0.74
 
     # Tests Pareto; r_squared ~ 1
-    pareto_draw = np.exp(np.random.exponential(scale=1.0, size=sample_size))
+    pareto_draw = np.exp(rng.exponential(scale=1.0, size=sample_size))
     rank_data, size_data = rank_size(pareto_draw, c=c)
 
     assert len(rank_data) == len(size_data)
@@ -120,7 +120,7 @@ def test_rank_size():
     assert_allclose(r_sqval, 1, rtol=1e-3)
 
     # Tests Exponential; r_squared < 1
-    z = np.random.randn(sample_size)
+    z = rng.standard_normal(sample_size)
 
     exp_draw = np.exp(z)
     rank_data_exp, size_data_exp = rank_size(exp_draw, c=c)

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -100,7 +100,7 @@ class TestQuadrect:
 
         # Integration parameters
         n = np.array([5, 11, 21, 51, 101, 401])  # number of nodes
-        np.random.seed(42)  # same seed as ML code.
+        random_state = np.random.RandomState(42) # same seed as ML code.
         a, b = -1, 1  # endpoints
 
         # Set up pandas DataFrame to hold results
@@ -114,10 +114,9 @@ class TestQuadrect:
             for kind in kinds:
                 for num in n:
                     num_in = num ** 2 if len(kind) == 1 else num
-                    quad_rect_res1d.loc[func_name, num][kind] = quadrect(func,
-                                                                        num_in,
-                                                                        a, b,
-                                                                        kind)
+                    quad_rect_res1d.loc[func_name, num][kind] = \
+                        quadrect(func, num_in, a, b, kind,
+                                 random_state=random_state)
 
         cls.data1d = quad_rect_res1d
 

--- a/quantecon/util/__init__.py
+++ b/quantecon/util/__init__.py
@@ -5,5 +5,5 @@ API for QuantEcon Utilities
 
 from .array import searchsorted
 from .notebooks import fetch_nb_dependencies
-from .random import check_random_state
+from .random import check_random_state, rng_integers
 from .timing import tic, tac, toc, loop_timer

--- a/quantecon/util/random.py
+++ b/quantecon/util/random.py
@@ -5,28 +5,36 @@ Utilities to Support Random State Infrastructure
 import numpy as np
 import numbers
 
-#-Random States-#
+
+# Random States
 
 def check_random_state(seed):
     """
-    Check the random state of a given seed.
+    Turn `seed` into a `np.random.RandomState` instance.
 
-    If seed is None, return the RandomState singleton used by np.random.
-    If seed is an int, return a new RandomState instance seeded with seed.
-    If seed is already a RandomState instance, return it.
+    Parameters
+    ----------
+    seed : None, int, `np.random.RandomState`, or `np.random.Generator`
+        If None, the `np.random.RandomState` singleton is returned. If
+        `seed` is an int, a new ``RandomState`` instance seeded with
+        `seed` is returned. If `seed` is already a `RandomState` or
+        `Generator` instance, then that instance is returned.
 
-    Otherwise raise ValueError.
+    Returns
+    -------
+    `np.random.RandomState` or `np.random.Generator`
+        Random number generator.
 
     Notes
     -----
-    This code was sourced from scikit-learn.
+    This code was originally sourced from scikit-learn.
 
     """
     if seed is None or seed is np.random:
         return np.random.mtrand._rand
     if isinstance(seed, (numbers.Integral, np.integer)):
         return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState):
+    if isinstance(seed, (np.random.RandomState, np.random.Generator)):
         return seed
     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
                      ' instance' % seed)

--- a/quantecon/util/random.py
+++ b/quantecon/util/random.py
@@ -5,6 +5,9 @@ Utilities to Support Random State Infrastructure
 import numpy as np
 import numbers
 
+# To be called as util.rng_integers
+from scipy._lib._util import rng_integers  # noqa: F401
+
 
 # Random States
 


### PR DESCRIPTION
Numpy's recommended procedure to generate random numbers now seems to be to use `np.random.Generator` instead of `np.random.RandomState`: https://numpy.org/doc/stable/reference/random/index.html

This PR is to update `check_random_state` to accept `np.random.Generator`, following the corresponding code in scipy:
https://github.com/scipy/scipy/blob/b4a970bf4eba1065ea31f8d0988cd4ec523a07d4/scipy/_lib/_util.py#L174-L203

There are discussions on this at scipy and scikit-learn:
* scipy/scipy#13778
* scikit-learn/scikit-learn#16988
* scikit-learn/scikit-learn#22271
* scikit-learn/scikit-learn#23962

The issue is that some methods are present for `np.random.RandomState` but not for `np.random.Generator`: see the table in [here](https://numpy.org/doc/stable/reference/random/index.html#quick-start). Thus, for example, `random_sample()` and `rand()` have to be replaced with `random()`, and `randn()` with `standard_normal()` and so on.
These can be done as commits added to this PR or as independent PRs.

TODOs:
* [x] Replace `np.random.RandomState` specific methods to `np.random.Generator` compatible methods
  - [x] `random_sample()` -> `random()`
  - [x] `rand()` -> `random()`, but `rand(d0, d1, ..., dn)` -> `random((d0, d1, ..., dn))` (or `random(size=(d0, d1, ..., dn))`)
  - [x] `randn()` -> `standard_normal()`, but `randn(d0, d1, ..., dn)` -> `standard_normal((d0, d1, ..., dn))` (or `standard_normal(size=(d0, d1, ..., dn))`)
  - [x] `randint()` -> `util.rng_integers()`
* [x] Update docstrings
* [x] Add tests