### PR TITLE
RFC: Replace `rand()` and `random_sample()` with `random()` in game_theory

### DIFF
--- a/quantecon/game_theory/brd.py
+++ b/quantecon/game_theory/brd.py
@@ -171,7 +171,7 @@ class KMR(BRD):
         tol = options.get('tol', None)
         random_state = check_random_state(options.get('random_state', None))
 
-        if random_state.rand() < self.epsilon:  # Mutation
+        if random_state.random() < self.epsilon:  # Mutation
             action_dist[action] -= 1
             random_state = check_random_state(random_state)
             next_action = self.player.random_choice(random_state=random_state)

--- a/quantecon/game_theory/game_generators/bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/bimatrix_generators.py
@@ -590,7 +590,7 @@ def unit_vector_game(n, avoid_pure_nash=False, random_state=None):
 
     """
     random_state = check_random_state(random_state)
-    payoff_arrays = (np.zeros((n, n)), random_state.random_sample((n, n)))
+    payoff_arrays = (np.zeros((n, n)), random_state.random((n, n)))
 
     if not avoid_pure_nash:
         ones_ind = random_state.randint(n, size=n)
@@ -603,7 +603,7 @@ def unit_vector_game(n, avoid_pure_nash=False, random_state=None):
         nums_suboptimal = is_suboptimal.sum(axis=1)
 
         while (nums_suboptimal==0).any():
-            payoff_arrays[1][:] = random_state.random_sample((n, n))
+            payoff_arrays[1][:] = random_state.random((n, n))
             payoff_arrays[1].max(axis=0, out=maxes)
             np.less(payoff_arrays[1], maxes, out=is_suboptimal)
             is_suboptimal.sum(axis=1, out=nums_suboptimal)

--- a/quantecon/game_theory/logitdyn.py
+++ b/quantecon/game_theory/logitdyn.py
@@ -70,7 +70,7 @@ class LogitDynamics:
             tuple(actions[i+1:]) + tuple(actions[:i])
 
         cdf = self.players[i].logit_choice_cdfs[opponent_actions]
-        random_value = random_state.rand()
+        random_value = random_state.random()
         next_action = cdf.searchsorted(random_value*cdf[-1], side='right')
 
         return next_action

--- a/quantecon/game_theory/random.py
+++ b/quantecon/game_theory/random.py
@@ -37,7 +37,7 @@ def random_game(nums_actions, random_state=None):
 
     random_state = check_random_state(random_state)
     players = [
-        Player(random_state.random_sample(nums_actions[i:]+nums_actions[:i]))
+        Player(random_state.random(nums_actions[i:]+nums_actions[:i]))
         for i in range(N)
     ]
     g = NormalFormGame(players)
@@ -146,7 +146,7 @@ def _random_mixed_actions(out, random_state):
         if n == 1:
             x[0] = 1
         else:
-            r = random_state.random_sample(size=n-1)
+            r = random_state.random(size=n-1)
             _probvec_cpu(r, x)
     return out
 

--- a/quantecon/game_theory/tests/test_support_enumeration.py
+++ b/quantecon/game_theory/tests/test_support_enumeration.py
@@ -19,7 +19,7 @@ def random_skew_sym(n, m=None, random_state=None):
     if m is None:
         m = n
     random_state = check_random_state(random_state)
-    B = random_state.random_sample((n, m))
+    B = random_state.random((n, m))
     A = np.empty((n+m, n+m))
     A[:n, :n] = 0
     A[n:, n:] = 0


### PR DESCRIPTION
Towards #654

There is absolutely no change in the returns of the code:

```py
>>> random_state = np.random.RandomState(123);
>>> random_state.rand(3)
array([0.69646919, 0.28613933, 0.22685145])
```

```py
>>> random_state = np.random.RandomState(123);
>>> random_state.random_sample(3)
array([0.69646919, 0.28613933, 0.22685145])
```

```py
>>> random_state = np.random.RandomState(123);
>>> random_state.random(3)
array([0.69646919, 0.28613933, 0.22685145])
```