### PR TITLE
FIX: Fix dtype in `cartesian`

### DIFF
--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -30,7 +30,7 @@ def cartesian(nodes, order='C'):
     nodes = [np.array(e) for e in nodes]
     shapes = [e.shape[0] for e in nodes]
 
-    dtype = nodes[0].dtype
+    dtype = np.result_type(*nodes)
 
     n = len(nodes)
     l = np.prod(shapes)

--- a/quantecon/gridtools.py
+++ b/quantecon/gridtools.py
@@ -27,7 +27,7 @@ def cartesian(nodes, order='C'):
         each line corresponds to one point of the product space
     '''
 
-    nodes = [np.array(e) for e in nodes]
+    nodes = [np.asarray(e) for e in nodes]
     shapes = [e.shape[0] for e in nodes]
 
     dtype = np.result_type(*nodes)
@@ -75,9 +75,9 @@ def mlinspace(a, b, nums, order='C'):
         each line corresponds to one point of the product space
     '''
 
-    a = np.array(a, dtype='float64')
-    b = np.array(b, dtype='float64')
-    nums = np.array(nums, dtype='int64')
+    a = np.asarray(a, dtype='float64')
+    b = np.asarray(b, dtype='float64')
+    nums = np.asarray(nums, dtype='int64')
     nodes = [np.linspace(a[i], b[i], nums[i]) for i in range(len(nums))]
 
     return cartesian(nodes, order=order)

--- a/quantecon/tests/test_gridtools.py
+++ b/quantecon/tests/test_gridtools.py
@@ -36,6 +36,19 @@ def test_cartesian_C_order_int_float():
     assert_(abs(prod_int-prod_float).max() == 0)
 
 
+def test_cartesian_C_order_int_float_mixed():
+    x_int = [0, 1]
+    x_float = [2.3, 4.5]
+    prod_expected = np.array(
+        [[0., 2.3],
+         [0., 4.5],
+         [1., 2.3],
+         [1., 4.5]]
+    )
+    prod_computed = cartesian([x_int, x_float])
+    assert_array_equal(prod_computed, prod_expected)
+
+
 def test_cartesian_F_order():
     x = np.linspace(0, 9, 10)
 


### PR DESCRIPTION
Current code:

```python
>>> nodes = [[0, 1], [2.3, 4.5]]
>>> qe.cartesian(nodes)
array([[0, 2],
       [0, 4],
       [1, 2],
       [1, 4]])
```

This PR:

```python
>>> nodes = [[0, 1], [2.3, 4.5]]
>>> qe.cartesian(nodes)
array([[0. , 2.3],
       [0. , 4.5],
       [1. , 2.3],
       [1. , 4.5]])
```