### PR TITLE
RFC: Avoid bare `@jit`

### DIFF
--- a/quantecon/_lss.py
+++ b/quantecon/_lss.py
@@ -11,7 +11,7 @@ from numba import jit
 from .util import check_random_state
 
 
-@jit
+@jit(nopython=True)
 def simulate_linear_model(A, x0, v, ts_length):
     r"""
     This is a separate function for simulating a vector linear system of


### PR DESCRIPTION
To avoid `NumbaDeprecationWarning`

```
NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
```