### PR TITLE
FIX: DOC: Remove `html4_writer = True`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,8 +161,6 @@ else:  # Local build. Need to import rtd theme
   html_theme = "sphinx_rtd_theme"
   html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-html4_writer = True
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
Fix the build error "HTML 4 is no longer supported by Sphinx": https://readthedocs.org/projects/quanteconpy/builds/20742271/