### PR TITLE
ENH: add njit interpolation functions

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -33,7 +33,7 @@ from ._gridtools import (
 )
 from ._inequality import lorenz_curve, gini_coefficient, shorrocks_index, \
     rank_size
-from ._interpolation import interp, interpf, interpa
+from ._interpolation import interp
 from ._kalman import Kalman
 from ._lae import LAE
 from ._arma import ARMA

--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -33,6 +33,7 @@ from ._gridtools import (
 )
 from ._inequality import lorenz_curve, gini_coefficient, shorrocks_index, \
     rank_size
+from ._interpolation import interp, interpf, interpa
 from ._kalman import Kalman
 from ._lae import LAE
 from ._arma import ARMA

--- a/quantecon/_interpolation.py
+++ b/quantecon/_interpolation.py
@@ -1,0 +1,107 @@
+from numba import njit
+
+@njit
+def interp(x, xp, fp):
+    """
+    Linearly interpolate (xp, fp) to evaluate at x.
+    
+    Here xp must be regular (evenly spaced).
+
+    Parameters
+    ----------
+    x : float, or np.array
+        The x-coordinate at which to evaluate the interpolated values.
+
+    xp : np.array(floats)
+         The x-coordinates of the data points
+
+    fp : np.array(floats)
+         The y-coordinates of the data points (same length as xp)
+
+    Returns
+    -------
+    y : float or np.array
+        the interpolated value(s) with return type dependent on x
+
+    Raises
+    ------
+    ValueError
+        if xp and fp have different lengths
+    """
+    
+    if len(xp) != len(fp):
+        raise ValueError("xp and fp must be the same length")
+
+    if isinstance(x, float):
+        return interpf(x, xp, fp)
+    else:
+        return interpa(x, xp, fp)
+
+
+@njit
+def interpf(x, xp, fp):
+    """
+    Linearly interpolate (xp, fp) to evaluate at x.
+    
+    Here xp must be regular (evenly spaced).
+
+    Parameters
+    ----------
+    x : float
+        The x-coordinate at which to evaluate the interpolated values.
+
+    xp : np.array(floats)
+         The x-coordinates of the data points
+
+    fp : np.array(floats)
+         The y-coordinates of the data points (same length as xp)
+
+    Returns
+    -------
+    y : float
+        the interpolated value
+
+    Raises
+    ------
+    ValueError
+        if xp and fp have different lengths
+    """
+
+    a, b, len_g = np.min(xp), np.max(xp), len(xp)
+    s = (x - a) / (b - a)
+    q_0 = max(min(int(s * (len_g - 1)), (len_g - 2)), 0)
+    v_0 = fp[q_0]
+    v_1 = fp[q_0 + 1]
+    λ = s * (len_g - 1) - q_0
+    y = (1 - λ) * v_0 + λ * v_1
+    return y
+
+
+@njit
+def interpa(x, xp, fp):
+    """
+    Linearly interpolate (xp, fp) to evaluate an array of x.
+    
+    Here xp must be regular (evenly spaced).
+
+    Parameters
+    ----------
+    x : np.array(float)
+        The x-coordinate's at which to evaluate the interpolated values.
+
+    xp : np.array(float)
+         The x-coordinates of the data points
+
+    fp : np.array(float)
+         The y-coordinates of the data points (same length as xp)
+
+    Returns
+    -------
+    y : np.array(float)
+        the interpolated values
+    """
+
+    y = np.empty_like(x)
+    for idx in range(len(x)):
+        y[idx] = interpf(x[idx], xp, fp)
+    return y

--- a/quantecon/_interpolation.py
+++ b/quantecon/_interpolation.py
@@ -28,18 +28,18 @@ def interp(x, xp, fp):
     ValueError
         if xp and fp have different lengths
     """
-    
+
     if len(xp) != len(fp):
         raise ValueError("xp and fp must be the same length")
 
     if isinstance(x, float):
-        return interpf(x, xp, fp)
+        return _interpf(x, xp, fp)
     else:
-        return interpa(x, xp, fp)
+        return _interpa(x, xp, fp)
 
 
 @njit
-def interpf(x, xp, fp):
+def _interpf(x, xp, fp):
     """
     Linearly interpolate (xp, fp) to evaluate at x.
     
@@ -78,7 +78,7 @@ def interpf(x, xp, fp):
 
 
 @njit
-def interpa(x, xp, fp):
+def _interpa(x, xp, fp):
     """
     Linearly interpolate (xp, fp) to evaluate an array of x.
     

--- a/quantecon/tests/test_interpolation.py
+++ b/quantecon/tests/test_interpolation.py
@@ -1,7 +1,6 @@
 import numpy as np
 from quantecon._interpolation import interp, _interpf, _interpa
 
-import pytest
 from numpy.testing import assert_allclose
 
 def test_interp_float():

--- a/quantecon/tests/test_interpolation.py
+++ b/quantecon/tests/test_interpolation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from quantecon._interpolation import interp, interpf, interpa
+from quantecon._interpolation import interp, _interpf, _interpa
 
 import pytest
 from numpy.testing import assert_allclose
@@ -8,7 +8,7 @@ def test_interp_float():
     xp = np.array([1, 2, 3])
     fp = np.array([3, 2, 0])
     numpy_y = np.interp(2.5, xp, fp)
-    qe_y = interpf(2.5, xp, fp)
+    qe_y = _interpf(2.5, xp, fp)
     assert_allclose(qe_y, numpy_y)
     qe_y2 = interp(2.5, xp, fp)
     assert_allclose(qe_y2, numpy_y)
@@ -19,7 +19,7 @@ def test_interp_array():
     y = np.sin(x)
     xvals = np.linspace(0, 2*np.pi, 50)
     numpy_y = np.interp(xvals, x, y)
-    qe_y = interpa(xvals, x, y)
+    qe_y = _interpa(xvals, x, y)
     assert_allclose(qe_y, numpy_y)
     qe_y2 = interp(xvals, x, y)
     assert_allclose(qe_y2, numpy_y)

--- a/quantecon/tests/test_interpolation.py
+++ b/quantecon/tests/test_interpolation.py
@@ -1,0 +1,25 @@
+import numpy as np
+from quantecon._interpolation import interp, interpf, interpa
+
+import pytest
+from numpy.testing import assert_allclose
+
+def test_interp_float():
+    xp = np.array([1, 2, 3])
+    fp = np.array([3, 2, 0])
+    numpy_y = np.interp(2.5, xp, fp)
+    qe_y = interpf(2.5, xp, fp)
+    assert_allclose(qe_y, numpy_y)
+    qe_y2 = interp(2.5, xp, fp)
+    assert_allclose(qe_y2, numpy_y)
+
+
+def test_interp_array():
+    x = np.linspace(0, 2*np.pi, 10)
+    y = np.sin(x)
+    xvals = np.linspace(0, 2*np.pi, 50)
+    numpy_y = np.interp(xvals, x, y)
+    qe_y = interpa(xvals, x, y)
+    assert_allclose(qe_y, numpy_y)
+    qe_y2 = interp(xvals, x, y)
+    assert_allclose(qe_y2, numpy_y)


### PR DESCRIPTION
This PR adds the following interpolation functions

- `interp` that accepts x as `float` or `np.array`

and the following internal functions:

- `_interpf` that accepts x as `float`
- `_interpa` that accepts x as `np.array`
