### PR TITLE
Fix deprecation warnings coming from `np.asarray`

### DIFF
--- a/quantecon/_graph_tools.py
+++ b/quantecon/_graph_tools.py
@@ -137,7 +137,7 @@ class DiGraph:
         if values is None:
             self._node_labels = None
         else:
-            values = np.asarray(values)
+            values = np.asanyarray(values)
             if (values.ndim < 1) or (values.shape[0] != self.n):
                 raise ValueError(
                     'node_labels must be an array_like of length n'

--- a/quantecon/markov/core.py
+++ b/quantecon/markov/core.py
@@ -227,7 +227,7 @@ class MarkovChain:
         if values is None:
             self._state_values = None
         else:
-            values = np.asarray(values)
+            values = np.asanyarray(values)
             if (values.ndim < 1) or (values.shape[0] != self.n):
                 raise ValueError(
                     'state_values must be an array_like of length n'


### PR DESCRIPTION
Fix deprecation warnings coming from `np.asarray`.
Related to #723 