### PR TITLE
FIX: linprog_simplex: Fix bug in Phase 1

### DIFF
--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -163,14 +163,9 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
 
     # Phase 1
     success, status, num_iter_1 = \
-        solve_tableau(tableau, basis, max_iter, skip_aux=False,
-                      piv_options=piv_options)
+        solve_phase_1(tableau, basis, max_iter, piv_options=piv_options)
     num_iter += num_iter_1
-    if not success:  # max_iter exceeded
-        return SimplexResult(x, lambd, fun, success, status, num_iter)
-    if tableau[-1, -1] > piv_options.fea_tol:  # Infeasible
-        success = False
-        status = 2
+    if not success:
         return SimplexResult(x, lambd, fun, success, status, num_iter)
 
     # Modify the criterion row for Phase 2
@@ -440,6 +435,32 @@ def solve_tableau(tableau, basis, max_iter=10**6, skip_aux=True,
         basis[pivrow] = pivcol
 
     return success, status, num_iter
+
+
+@jit(nopython=True, cache=True)
+def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
+    """
+    Perform the simplex algorithm for Phase 1 on a given tableau in
+    canonical form, by calling `solve_tableau` with `skip_aux=False`.
+
+    Parameters
+    ----------
+    See `solve_tableau`.
+
+    Returns
+    -------
+    See `solve_tableau`.
+
+    """
+    success, status, num_iter_1 = \
+        solve_tableau(tableau, basis, max_iter, skip_aux=False,
+                      piv_options=piv_options)
+
+    if success and tableau[-1, -1] > piv_options.fea_tol:  # Infeasible
+        success = False
+        status = 2
+
+    return success, status, num_iter_1
 
 
 @jit(nopython=True, cache=True)

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -239,3 +239,15 @@ class TestLinprogSimplexScipy:
         desired_fun = -36.0000000000
         res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
         _assert_success(res, c, b_ub=b_ub, desired_fun=desired_fun)
+
+
+class TestLinprogSimplex:
+    def test_phase_1_bug_725(self):
+        # Identified a bug in Phase 1
+        # https://github.com/QuantEcon/QuantEcon.py/issues/725
+        c = np.array([-4.09555556, 4.59044444])
+        A_ub = np.array([[1, 0.1], [-1, -0.1], [1, 1]])
+        b_ub = np.array([9.1, -0.1, 0.1])
+        desired_x = [0.1, 0]
+        res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
+        _assert_success(res, c, b_ub=b_ub, desired_x=desired_x)


### PR DESCRIPTION
Fix #725

Simplified instance:

```python
c = np.array([-1,  1])
A_ub = np.array([[-2, -1], [1, 1]])
b_ub = np.array([-2, 1])
linprog_simplex(c=c, A_ub=A_ub, b_ub=b_ub)
```

Pre-bugfix version:

```
SimplexResult(x=array([0., 1.]), lambd=array([0., 1.]), fun=1.0, success=True, status=0, num_iter=4)
```

This bugfix version:

```
SimplexResult(x=array([ 1., -0.]), lambd=array([2., 3.]), fun=-1.0, success=True, status=0, num_iter=4)
```

Instances reported in #725:

```python
c = np.array([-392.62555556, 1260.73744444])
A_ub = np.array([[1, 0.1], [-1, -0.1], [1, 1]])
b_ub = np.array([10,-10,10])
linprog_simplex(c=c, A_ub=A_ub, b_ub=b_ub)
```

```
SimplexResult(x=array([10., -0.]), lambd=array([   0.        , 1837.07      , 1444.44444444]), fun=-3926.2555556, success=True, status=0, num_iter=5)
```

```python
c = np.array([-4.09555556,  4.59044444])
A_ub = np.array([[1, 0.1], [-1, -0.1], [1, 1]])
b_ub = np.array([9.1,-0.1,0.1])
linprog_simplex(c=c, A_ub=A_ub, b_ub=b_ub)
```

```
SimplexResult(x=array([ 0.1, -0. ]), lambd=array([0.        , 9.65111111, 5.55555555]), fun=-0.40955555600000004, success=True, status=0, num_iter=5)
```
