### PR TITLE
Add __repr__ for PolymatrixGame

### DIFF
--- a/quantecon/game_theory/polymatrix_game.py
+++ b/quantecon/game_theory/polymatrix_game.py
@@ -39,7 +39,7 @@ from collections.abc import Sequence, Mapping, Iterable
 # from typing import TypeAlias, Self
 from numpy.typing import NDArray
 
-from .normal_form_game import NormalFormGame, Player
+from .normal_form_game import NormalFormGame, Player, _nums_actions2string
 
 
 def hh_payoff_player(
@@ -155,6 +155,10 @@ class PolymatrixGame:
         Maps each pair of player numbers to a matrix.
 
     """
+    def __repr__(self):
+        s = '<{nums_actions} {N}-player PolymatrixGame>'
+        return s.format(nums_actions=_nums_actions2string(self.nums_actions),
+                        N=self.N)
 
     def __str__(self) -> str:
         str_builder = (


### PR DESCRIPTION
Similar to that of `NormalFormGame`.

```
>>> g = gt.random_game((2, 3, 4))
>>> g
<2x3x4 3-player NormalFormGame of dtype float64>
>>> polymg = gt.random_polymatrix_game((2, 3, 4))
>>> polymg
<2x3x4 3-player PolymatrixGame>
```

@GautamsGitHub By the way, shall we enforce homogeneous dtype across players in `PolymatrixGame`, as in `NormalFormGame`?
https://github.com/QuantEcon/QuantEcon.py/blob/b733469cae922e7956b23d782054329d464129f7/quantecon/game_theory/normal_form_game.py#L566-L591