### PR TITLE
CI: Update `actions/cache`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache conda
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         CACHE_NUMBER: 0
       with:


### PR DESCRIPTION
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down