### PR TITLE
FIX: Fix deprecations in tests

### DIFF
--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -586,5 +586,5 @@ def test_raises_value_error_simulate_init_out_of_range():
 
 def test_raises_non_homogeneous_state_values():
     P = [[0.4, 0.6], [0.2, 0.8]]
-    state_values = [(0, 1), 2]
+    state_values = np.array([(0, 1), 2], dtype=object)
     assert_raises(ValueError, MarkovChain, P, state_values=state_values)

--- a/quantecon/tests/test_graph_tools.py
+++ b/quantecon/tests/test_graph_tools.py
@@ -290,7 +290,7 @@ def test_raises_value_error_non_sym():
 
 def test_raises_non_homogeneous_node_labels():
     adj_matrix = [[1, 0], [0, 1]]
-    node_labels = [(0, 1), 2]
+    node_labels = np.array([(0, 1), 2], dtype=object)
     assert_raises(ValueError, DiGraph, adj_matrix, node_labels=node_labels)
 
 


### PR DESCRIPTION
Fix #723
Supersede and close #726

Create `ndarray`s with `dtype=object`, as described in https://github.com/QuantEcon/QuantEcon.py/pull/726#issuecomment-1982612655