### PR TITLE
CI: Update Numba to 0.61.0rc2

### DIFF
--- a/environment_np2.yml
+++ b/environment_np2.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy>=2
   - scipy
   - pandas
-  - numba=0.61.0rc1
+  - numba=0.61.0rc2
   - sympy
   - ipython
   - flake8


### PR DESCRIPTION
https://numba.discourse.group/t/ann-numba-0-61-0rc2-and-llvmlite-0-44-0rc2-are-out