### PR TITLE
RLS: setup for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+Future CHANGELOG entries will be documented under the [release notes on GitHub](https://github.com/QuantEcon/QuantEcon.py/releases)
+
+## Ver 0.8.0 (13th-Feb-2025)
+
+See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.8.0)
+
 ## Ver 0.7.2 (14th-March-2024)
 
 ### Fix

--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.7.2'
+__version__ = '0.8.0'
 
 try:
     import numba


### PR DESCRIPTION
This PR sets up the release of `0.8.0`

@oyamad I thought we would increment to `0.8.0` as there are some `ENH` entries and new features in the change notes. 

Also I propose we use the GitHub release notes mechanism moving forward, rather than using the `CHANGELOG.md` file. Would this be OK? 

I have added a note to `CHANGELOG.md` but let me know if you think we should keep both. Thanks. 