### PR TITLE
RFC: game_theory: Use numba.typed.Dict in `_vertex_enumeration_gen`

### DIFF
--- a/quantecon/game_theory/vertex_enumeration.py
+++ b/quantecon/game_theory/vertex_enumeration.py
@@ -11,7 +11,8 @@ Tardos, and V. Vazirani eds., Algorithmic Game Theory, 2007.
 """
 import numpy as np
 import scipy.spatial
-from numba import jit, guvectorize
+from numba import jit, guvectorize, types
+from numba.typed import Dict
 
 
 def vertex_enumeration(g, qhull_options=None):
@@ -109,18 +110,26 @@ def _vertex_enumeration_gen(labelings_bits_tup, equations_tup, trans_recips):
     ZERO_LABELING0_BITS = (np.uint64(1) << np.uint64(m)) - np.uint64(1)
     COMPLETE_LABELING_BITS = (np.uint64(1) << np.uint64(m+n)) - np.uint64(1)
 
+    labelings_bits_dict1 = Dict.empty(key_type=types.uint64,
+                                      value_type=types.intp)
+    for j in range(num_vertices1):
+        labelings_bits_dict1[labelings_bits_tup[1][j]] = j
+
     for i in range(num_vertices0):
-        if labelings_bits_tup[0][i] == ZERO_LABELING0_BITS:
+        bits0 = labelings_bits_tup[0][i]
+        if bits0 == ZERO_LABELING0_BITS:
             continue
-        for j in range(num_vertices1):
-            xor = labelings_bits_tup[0][i] ^ labelings_bits_tup[1][j]
-            if xor == COMPLETE_LABELING_BITS:
-                yield _get_mixed_actions(
-                    labelings_bits_tup[0][i],
-                    (equations_tup[0][i], equations_tup[1][j]),
-                    trans_recips
-                )
-                break
+        complement0 = bits0 ^ COMPLETE_LABELING_BITS
+        try:
+            j = labelings_bits_dict1[complement0]
+        except Exception:
+            continue
+
+        yield _get_mixed_actions(
+            bits0,
+            (equations_tup[0][i], equations_tup[1][j]),
+            trans_recips
+        )
 
 
 class _BestResponsePolytope:


### PR DESCRIPTION
I let ChatGPT read the existing code of [`vertex_enumeration.py`](https://github.com/QuantEcon/QuantEcon.py/blob/main/quantecon/game_theory/vertex_enumeration.py) and got the following suggestion:
* The current [`_vertex_enumeration_gen`](https://github.com/QuantEcon/QuantEcon.py/blob/23a8a9bfd5719ca358d7b9118cd19fad7dc2fe12/quantecon/game_theory/vertex_enumeration.py#L88-L123) has complexity `O(V_0 * V_1)`, where `V_i` is the number of vertices of the best response polytope of player `i`.
* One should use Dict in place of the inner loop, which will reduce the complexity to `O(V_0 + V_1)`.

Benchmarks with random n x n games showed significant speedups, and larger speedups for larger games: about 1.3x faster for n=12, 2x faster for n=14, 15, and 4x faster for n=17. (And no additional overheads for small size games.)