### PR TITLE
RLS: setup for v0.8.1

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 try:
     import numba


### PR DESCRIPTION
This PR sets up for release `v0.8.1`