### PR TITLE
RLS: prepare for v0.9.0

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 
 try:
     import numba


### PR DESCRIPTION
This PR sets up `v0.9.0` release. 

I have incremented from `v0.8.2` to `v0.9.0` due to the inclusion of new features such as the Timer. 