### PR TITLE
RLS: prepare for v0.10.0

### DIFF
--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 try:
     import numba


### PR DESCRIPTION
This PR prepares for `v0.10.0` that incorporate the latest changes and new feature (timeit)