### PR TITLE
RFC: avoid redundant `np.eye` and precompute identity matrix in `howson_lcp.py` M construction

### DIFF
--- a/quantecon/game_theory/howson_lcp.py
+++ b/quantecon/game_theory/howson_lcp.py
@@ -86,6 +86,9 @@ def polym_lcp_solver(
     LOW_AVOIDER = 2.0
     # makes all of the costs greater than 0
     positive_cost_maker = polymg.range_of_payoffs()[1] + LOW_AVOIDER
+
+    eye_N = np.eye(polymg.N)
+    
     # Construct the LCP like Howson:
     M = np.vstack([
         np.hstack([
@@ -96,13 +99,13 @@ def polym_lcp_solver(
             for p2 in range(polymg.N)
         ] + [
             -np.outer(np.ones(
-                polymg.nums_actions[player]), np.eye(polymg.N)[player])
+                polymg.nums_actions[player]), eye_N[player])
         ])
         for player in range(polymg.N)
     ] + [
         np.hstack([
             np.hstack([
-                np.outer(np.eye(polymg.N)[player], np.ones(
+                np.outer(eye_N[player], np.ones(
                     polymg.nums_actions[player]))
                 for player in range(polymg.N)
             ]

--- a/quantecon/game_theory/howson_lcp.py
+++ b/quantecon/game_theory/howson_lcp.py
@@ -88,7 +88,7 @@ def polym_lcp_solver(
     positive_cost_maker = polymg.range_of_payoffs()[1] + LOW_AVOIDER
 
     eye_N = np.eye(polymg.N)
-    
+
     # Construct the LCP like Howson:
     M = np.vstack([
         np.hstack([


### PR DESCRIPTION
## Summary
This PR makes a small refactor in `quantecon.game_theory.howson_lcp`.

- The code previously called `np.eye(polymg.N)` multiple times during the construction of the LCP matrix `M`. 
- This PR modifies it, computes the identity matrix once, and reuses it.

## Changes
- add `eye_N = np.eye(polymg.N)` before the `M` construction.
- replace repeated uses of `np.eye(polymg.N)[player]` with `eye_N[player]`

The existing logic remains the same (including `np.vstack` / `np.hstack` structure unchanged).

## Notes for Reviewers
All codes and documentation are written with assistance by LLMs.