### PR TITLE
DOCS: Add contributing entrypoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to QuantEcon.py
+
+Thanks for your interest in contributing to QuantEcon.py.
+
+The contribution guide is maintained in the project documentation:
+
+- [Rendered guide on Read the Docs](https://quanteconpy.readthedocs.io/en/latest/contributing.html)
+- [Source file in this repository](docs/source/contributing.rst)
+
+The guide covers where to start, how to set up a development environment,
+and expectations for tests and documentation.


### PR DESCRIPTION
## Summary

- add a root `CONTRIBUTING.md` entrypoint for GitHub's contributing-guidelines link
- point contributors to the rendered Read the Docs guide and the source `docs/source/contributing.rst`

## Context

This addresses the root `CONTRIBUTING.md` suggestion from #834 without duplicating the full contributing guide in two places.

## Validation

- Confirmed `docs/source/contributing.rst` exists in the repository
- Confirmed https://quanteconpy.readthedocs.io/en/latest/contributing.html returns HTTP 200