### PR TITLE
Add tests for Kalman.stationary_coefficients

### DIFF
--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -29,7 +29,9 @@ def _knowing_forecasts_of_others_kalman():
     https://python-advanced.quantecon.org/knowing_forecasts_of_others.html
 
     The lecture sets H=None (no observation noise). Kalman.stationary_values
-    requires H, so a negligible diagonal H is added for numerical use only.
+    requires H, so a small diagonal H is added for numerical use only.
+    Use 1e-4 rather than smaller values to avoid singular-matrix errors in
+    scipy.linalg.inv on some platforms (e.g. Python 3.14 on CI).
     """
     beta, rho, b = 0.9, 0.8, 1.5
     sigma_v, sigma_e = 0.5, 0.6
@@ -65,7 +67,7 @@ def _knowing_forecasts_of_others_kalman():
         [1., 0., 0., 0., 1., 0.],
         [1., 0., 0., 0., 0., 0.],
     ])
-    H = np.eye(G.shape[0]) * 1e-8
+    H = np.eye(G.shape[0]) * 1e-4
 
     return Kalman(LinearStateSpace(A, C, G, H))
 

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 from quantecon import LinearStateSpace
 from quantecon import Kalman
+from quantecon import solve_discrete_riccati
 
 
 RICCATI_METHODS = ['doubling', 'qz']
@@ -27,22 +28,36 @@ def _two_noisy_signals_kalman(rho=0.8, sigma_v=0.5, sigma_e=0.6):
     "Knowing the Forecasts of Others":
     https://python-advanced.quantecon.org/knowing_forecasts_of_others.html#two-noisy-signals
 
-    State: theta_{t+1} = rho theta_t + v_t
+    State: theta_{t+1} = rho theta_t + v_t,  Var(v_t) = sigma_v^2
     Observations: w_t = [1, 1]' theta_t + [e_1t, e_2t]'
     """
     A = np.array([[rho]])
-    C = np.array([[np.sqrt(sigma_v)]])
+    C = np.array([[sigma_v]])
     G = np.array([[1.], [1.]])
     H = np.eye(2) * sigma_e
     return Kalman(LinearStateSpace(A, C, G, H))
 
 
-def _expected_stationary_coefficients(kf, j, coeff_type):
-    """Closed-form reference using matrix powers."""
-    A, G = kf.ss.A, kf.ss.G
-    K = kf.K_infinity
+def _lecture_two_signal_kalman_gain(rho, sigma_v, sigma_e):
+    """
+    Stationary Kalman gain from lecture eqs. (37.25)-(37.26), independent of
+    Kalman.stationary_values.
+    """
+    p = solve_discrete_riccati(
+        np.array([[rho]]),
+        np.array([[np.sqrt(2.)]]),
+        np.array([[sigma_v ** 2]]),
+        np.array([[sigma_e ** 2]]),
+        np.zeros((1, 1)),
+    ).item()
+    kappa = rho * p / (2 * p + sigma_e ** 2)
+    return np.array([[kappa, kappa]])
+
+
+def _expected_stationary_coefficients(A, G, K, k, j, coeff_type):
+    """Closed-form coefficients using matrix powers and a supplied gain K."""
     if coeff_type == 'ma':
-        coeffs = [np.identity(kf.ss.k)]
+        coeffs = [np.identity(k)]
         coeffs.extend(
             G @ np.linalg.matrix_power(A, i) @ K for i in range(j)
         )
@@ -152,18 +167,22 @@ class TestKalmanStationaryCoefficients:
         kf = self.kf
         for method in self.methods:
             kf.stationary_values(method=method)
+            A, G, K, k = kf.ss.A, kf.ss.G, kf.K_infinity, kf.ss.k
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='ma')
-                expected = _expected_stationary_coefficients(kf, j, 'ma')
+                expected = _expected_stationary_coefficients(
+                    A, G, K, k, j, 'ma')
                 _assert_coeff_lists_equal(actual, expected)
 
     def test_stationary_coefficients_var(self):
         kf = self.kf
         for method in self.methods:
             kf.stationary_values(method=method)
+            A, G, K, k = kf.ss.A, kf.ss.G, kf.K_infinity, kf.ss.k
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='var')
-                expected = _expected_stationary_coefficients(kf, j, 'var')
+                expected = _expected_stationary_coefficients(
+                    A, G, K, k, j, 'var')
                 _assert_coeff_lists_equal(actual, expected)
 
     def test_stationary_coefficients_invalid_type(self):
@@ -175,32 +194,47 @@ class TestKalmanStationaryCoefficients:
 
 class TestKalmanStationaryCoefficientsTwoNoisySignals:
 
+    rho, sigma_v, sigma_e = 0.8, 0.5, 0.6
+
     def setup_method(self):
-        self.kf = _two_noisy_signals_kalman()
+        self.kf = _two_noisy_signals_kalman(
+            self.rho, self.sigma_v, self.sigma_e)
         self.methods = RICCATI_METHODS
+        self.K_ref = _lecture_two_signal_kalman_gain(
+            self.rho, self.sigma_v, self.sigma_e)
+
+    def test_stationary_kalman_gain_matches_lecture(self):
+        kf = self.kf
+        for method in self.methods:
+            kf.stationary_values(method=method)
+            assert_allclose(kf.K_infinity, self.K_ref, rtol=1e-10, atol=1e-10)
 
     def test_stationary_coefficients_ma(self):
         kf = self.kf
+        A, G, k = kf.ss.A, kf.ss.G, kf.ss.k
         for method in self.methods:
             kf.stationary_values(method=method)
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='ma')
-                expected = _expected_stationary_coefficients(kf, j, 'ma')
+                expected = _expected_stationary_coefficients(
+                    A, G, self.K_ref, k, j, 'ma')
                 _assert_coeff_lists_equal(actual, expected)
 
     def test_stationary_coefficients_var(self):
         kf = self.kf
+        A, G, k = kf.ss.A, kf.ss.G, kf.ss.k
         for method in self.methods:
             kf.stationary_values(method=method)
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='var')
-                expected = _expected_stationary_coefficients(kf, j, 'var')
+                expected = _expected_stationary_coefficients(
+                    A, G, self.K_ref, k, j, 'var')
                 _assert_coeff_lists_equal(actual, expected)
 
     def test_coefficients_are_not_diagonal(self):
         """Sanity check: (n, k) = (1, 2) model yields non-diagonal MA coefficients."""
-        kf = self.kf
-        kf.stationary_values()
-        psi_1 = kf.stationary_coefficients(1, coeff_type='ma')[1]
+        expected = _expected_stationary_coefficients(
+            self.kf.ss.A, self.kf.ss.G, self.K_ref, self.kf.ss.k, 1, 'ma')
+        psi_1 = expected[1]
         assert psi_1.shape == (2, 2)
         assert not np.allclose(psi_1, np.diag(np.diag(psi_1)))

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -84,3 +84,71 @@ class TestKalman:
 
         assert_allclose(kf.Sigma, new_sigma, rtol=1e-4, atol=1e-2)
         assert_allclose(kf.x_hat, new_xhat, rtol=1e-4, atol=1e-2)
+
+
+class TestKalmanStationaryCoefficients:
+
+    def setup_method(self):
+        self.A = np.array([[.95, 0], [0., .95]])
+        self.C = np.eye(2) * np.sqrt(0.5)
+        self.G = np.eye(2) * .5
+        self.H = np.eye(2) * np.sqrt(0.2)
+        ss = LinearStateSpace(self.A, self.C, self.G, self.H)
+        self.kf = Kalman(ss)
+        self.methods = ['doubling', 'qz']
+
+    @staticmethod
+    def _expected_stationary_coefficients(kf, j, coeff_type):
+        """Reference implementation for stationary_coefficients."""
+        A, G = kf.ss.A, kf.ss.G
+        K_infinity = kf.K_infinity
+        coeffs = []
+        if coeff_type == 'ma':
+            coeffs.append(np.identity(kf.ss.k))
+            P_mat = A
+            P = np.identity(kf.ss.n)
+        elif coeff_type == 'var':
+            coeffs.append(G @ K_infinity)
+            P_mat = A - (K_infinity @ G)
+            P = np.copy(P_mat)
+        else:
+            raise ValueError("Unknown coefficient type")
+        for i in range(1, j + 1):
+            coeffs.append((G @ P) @ K_infinity)
+            P = P @ P_mat
+        return coeffs
+
+    @staticmethod
+    def _assert_coeff_lists_equal(actual, expected):
+        assert len(actual) == len(expected)
+        for a, e in zip(actual, expected):
+            assert a.shape == e.shape
+            assert_allclose(a, e, rtol=1e-10, atol=1e-10)
+
+    def test_stationary_coefficients_ma(self):
+        kf = self.kf
+        for method in self.methods:
+            kf.stationary_values(method=method)
+            for j in (0, 1, 3):
+                actual = kf.stationary_coefficients(j, coeff_type='ma')
+                expected = self._expected_stationary_coefficients(kf, j, 'ma')
+                self._assert_coeff_lists_equal(actual, expected)
+
+    def test_stationary_coefficients_var(self):
+        kf = self.kf
+        for method in self.methods:
+            kf.stationary_values(method=method)
+            for j in (0, 1, 3):
+                actual = kf.stationary_coefficients(j, coeff_type='var')
+                expected = self._expected_stationary_coefficients(kf, j, 'var')
+                self._assert_coeff_lists_equal(actual, expected)
+
+    def test_stationary_coefficients_invalid_type(self):
+        kf = self.kf
+        kf.stationary_values()
+        try:
+            kf.stationary_coefficients(1, coeff_type='invalid')
+        except ValueError as e:
+            assert str(e) == "Unknown coefficient type"
+        else:
+            raise AssertionError("Expected ValueError was not raised")

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.testing import assert_allclose
 from quantecon import LinearStateSpace
 from quantecon import Kalman
-from quantecon import solve_discrete_riccati
 
 
 RICCATI_METHODS = ['doubling', 'qz']
@@ -38,18 +37,26 @@ def _two_noisy_signals_kalman(rho=0.8, sigma_v=0.5, sigma_e=0.6):
     return Kalman(LinearStateSpace(A, C, G, H))
 
 
+def _lecture_two_signal_posterior_variance(rho, sigma_v, sigma_e):
+    """
+    Solve lecture eq. (37.26) for p.
+
+    The Riccati equation reduces to
+    2 p^2 + p (sigma_e^2 - 2 sigma_v^2 - rho^2 sigma_e^2) - sigma_v^2 sigma_e^2 = 0.
+    """
+    a = 2.0
+    b = sigma_e ** 2 - 2 * sigma_v ** 2 - rho ** 2 * sigma_e ** 2
+    c = -sigma_v ** 2 * sigma_e ** 2
+    discriminant = b ** 2 - 4 * a * c
+    return (-b + np.sqrt(discriminant)) / (2 * a)
+
+
 def _lecture_two_signal_kalman_gain(rho, sigma_v, sigma_e):
     """
     Stationary Kalman gain from lecture eqs. (37.25)-(37.26), independent of
     Kalman.stationary_values.
     """
-    p = solve_discrete_riccati(
-        np.array([[rho]]),
-        np.array([[np.sqrt(2.)]]),
-        np.array([[sigma_v ** 2]]),
-        np.array([[sigma_e ** 2]]),
-        np.zeros((1, 1)),
-    ).item()
+    p = _lecture_two_signal_posterior_variance(rho, sigma_v, sigma_e)
     kappa = rho * p / (2 * p + sigma_e ** 2)
     return np.array([[kappa, kappa]])
 

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -7,6 +7,105 @@ import pytest
 from numpy.testing import assert_allclose
 from quantecon import LinearStateSpace
 from quantecon import Kalman
+from quantecon import solve_discrete_riccati
+
+
+RICCATI_METHODS = ['doubling', 'qz']
+
+
+def _symmetric_kalman():
+    """Simple diagonal 2D model used in the original Kalman tests."""
+    A = np.array([[.95, 0], [0., .95]])
+    C = np.eye(2) * np.sqrt(0.5)
+    G = np.eye(2) * .5
+    H = np.eye(2) * np.sqrt(0.2)
+    return Kalman(LinearStateSpace(A, C, G, H))
+
+
+def _knowing_forecasts_of_others_kalman():
+    """
+    Pooling-equilibrium state space from the QuantEcon lecture
+    "Knowing the Forecasts of Others":
+    https://python-advanced.quantecon.org/knowing_forecasts_of_others.html
+
+    The lecture sets H=None (no observation noise). Kalman.stationary_values
+    requires H, so a negligible diagonal H is added for numerical use only.
+    """
+    beta, rho, b = 0.9, 0.8, 1.5
+    sigma_v, sigma_e = 0.5, 0.6
+
+    poly = np.array([1, -(1 + beta + b) / beta, 1 / beta])
+    roots_poly = np.roots(poly)
+    lambda_tilde, lambda_ = roots_poly.min(), roots_poly.max()
+
+    p = solve_discrete_riccati_scalar(rho, sigma_v, sigma_e)
+    kappa = rho * p / (p + sigma_e ** 2)
+    kappa_prod = kappa * sigma_e ** 2 / p
+
+    A = np.array([
+        [0., 0., 0., 0., 0., 0.],
+        [kappa / (lambda_ - rho), lambda_tilde, -kappa_prod / (lambda_ - rho),
+         0., rho / (lambda_ - rho), 0.],
+        [-kappa, 0., kappa_prod, 0., 0., 1.],
+        [b * kappa / (lambda_ - rho), b * lambda_tilde,
+         -b * kappa_prod / (lambda_ - rho), 0., b * rho / (lambda_ - rho) + rho, 1.],
+        [0., 0., 0., 0., rho, 1.],
+        [0., 0., 0., 0., 0., 0.],
+    ])
+    C = np.array([
+        [sigma_e, 0.],
+        [0., 0.],
+        [0., 0.],
+        [sigma_e, 0.],
+        [0., 0.],
+        [0., sigma_v],
+    ])
+    G = np.array([
+        [0., 0., 0., 1., 0., 0.],
+        [1., 0., 0., 0., 1., 0.],
+        [1., 0., 0., 0., 0., 0.],
+    ])
+    H = np.eye(G.shape[0]) * 1e-8
+
+    return Kalman(LinearStateSpace(A, C, G, H))
+
+
+def solve_discrete_riccati_scalar(rho, sigma_v, sigma_e):
+    """Stationary variance p from the lecture's scalar Riccati equation."""
+    return solve_discrete_riccati(
+        np.array([[rho]]),
+        np.array([[1.]]),
+        np.array([[sigma_v ** 2]]),
+        np.array([[sigma_e ** 2]]),
+        np.zeros((1, 1)),
+    ).item()
+
+
+def _expected_stationary_coefficients(kf, j, coeff_type):
+    """Closed-form reference using matrix powers."""
+    A, G = kf.ss.A, kf.ss.G
+    K = kf.K_infinity
+    if coeff_type == 'ma':
+        coeffs = [np.identity(kf.ss.k)]
+        coeffs.extend(
+            G @ np.linalg.matrix_power(A, i) @ K for i in range(j)
+        )
+    elif coeff_type == 'var':
+        phi = A - K @ G
+        coeffs = [G @ K]
+        coeffs.extend(
+            G @ np.linalg.matrix_power(phi, i) @ K for i in range(1, j + 1)
+        )
+    else:
+        raise ValueError("Unknown coefficient type")
+    return coeffs
+
+
+def _assert_coeff_lists_equal(actual, expected):
+    assert len(actual) == len(expected)
+    for a, e in zip(actual, expected):
+        assert a.shape == e.shape
+        assert_allclose(a, e, rtol=1e-10, atol=1e-10)
 
 
 class TestKalman:
@@ -25,7 +124,7 @@ class TestKalman:
 
         self.kf = Kalman(ss)
 
-        self.methods = ['doubling', 'qz']
+        self.methods = RICCATI_METHODS
 
 
     def teardown_method(self):
@@ -90,40 +189,8 @@ class TestKalman:
 class TestKalmanStationaryCoefficients:
 
     def setup_method(self):
-        self.A = np.array([[.95, 0], [0., .95]])
-        self.C = np.eye(2) * np.sqrt(0.5)
-        self.G = np.eye(2) * .5
-        self.H = np.eye(2) * np.sqrt(0.2)
-        ss = LinearStateSpace(self.A, self.C, self.G, self.H)
-        self.kf = Kalman(ss)
-        self.methods = ['doubling', 'qz']
-
-    @staticmethod
-    def _expected_stationary_coefficients(kf, j, coeff_type):
-        """Closed-form reference using matrix powers."""
-        A, G = kf.ss.A, kf.ss.G
-        K = kf.K_infinity
-        if coeff_type == 'ma':
-            coeffs = [np.identity(kf.ss.k)]
-            coeffs.extend(
-                G @ np.linalg.matrix_power(A, i) @ K for i in range(j)
-            )
-        elif coeff_type == 'var':
-            phi = A - K @ G
-            coeffs = [G @ K]
-            coeffs.extend(
-                G @ np.linalg.matrix_power(phi, i) @ K for i in range(1, j + 1)
-            )
-        else:
-            raise ValueError("Unknown coefficient type")
-        return coeffs
-
-    @staticmethod
-    def _assert_coeff_lists_equal(actual, expected):
-        assert len(actual) == len(expected)
-        for a, e in zip(actual, expected):
-            assert a.shape == e.shape
-            assert_allclose(a, e, rtol=1e-10, atol=1e-10)
+        self.kf = _symmetric_kalman()
+        self.methods = RICCATI_METHODS
 
     def test_stationary_coefficients_ma(self):
         kf = self.kf
@@ -131,8 +198,8 @@ class TestKalmanStationaryCoefficients:
             kf.stationary_values(method=method)
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='ma')
-                expected = self._expected_stationary_coefficients(kf, j, 'ma')
-                self._assert_coeff_lists_equal(actual, expected)
+                expected = _expected_stationary_coefficients(kf, j, 'ma')
+                _assert_coeff_lists_equal(actual, expected)
 
     def test_stationary_coefficients_var(self):
         kf = self.kf
@@ -140,11 +207,43 @@ class TestKalmanStationaryCoefficients:
             kf.stationary_values(method=method)
             for j in (0, 1, 3):
                 actual = kf.stationary_coefficients(j, coeff_type='var')
-                expected = self._expected_stationary_coefficients(kf, j, 'var')
-                self._assert_coeff_lists_equal(actual, expected)
+                expected = _expected_stationary_coefficients(kf, j, 'var')
+                _assert_coeff_lists_equal(actual, expected)
 
     def test_stationary_coefficients_invalid_type(self):
         kf = self.kf
         kf.stationary_values()
         with pytest.raises(ValueError, match="Unknown coefficient type"):
             kf.stationary_coefficients(1, coeff_type='invalid')
+
+
+class TestKalmanStationaryCoefficientsKnowingForecasts:
+
+    def setup_method(self):
+        self.kf = _knowing_forecasts_of_others_kalman()
+        self.methods = RICCATI_METHODS
+
+    def test_stationary_coefficients_ma(self):
+        kf = self.kf
+        for method in self.methods:
+            kf.stationary_values(method=method)
+            for j in (0, 1, 3):
+                actual = kf.stationary_coefficients(j, coeff_type='ma')
+                expected = _expected_stationary_coefficients(kf, j, 'ma')
+                _assert_coeff_lists_equal(actual, expected)
+
+    def test_stationary_coefficients_var(self):
+        kf = self.kf
+        for method in self.methods:
+            kf.stationary_values(method=method)
+            for j in (0, 1, 3):
+                actual = kf.stationary_coefficients(j, coeff_type='var')
+                expected = _expected_stationary_coefficients(kf, j, 'var')
+                _assert_coeff_lists_equal(actual, expected)
+
+    def test_coefficients_are_not_diagonal(self):
+        """Sanity check: lecture matrices produce non-trivial coefficients."""
+        kf = self.kf
+        kf.stationary_values()
+        psi_1 = kf.stationary_coefficients(1, coeff_type='ma')[1]
+        assert not np.allclose(psi_1, np.diag(np.diag(psi_1)))

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.testing import assert_allclose
 from quantecon import LinearStateSpace
 from quantecon import Kalman
-from quantecon import solve_discrete_riccati
 
 
 RICCATI_METHODS = ['doubling', 'qz']
@@ -22,65 +21,20 @@ def _symmetric_kalman():
     return Kalman(LinearStateSpace(A, C, G, H))
 
 
-def _knowing_forecasts_of_others_kalman():
+def _two_noisy_signals_kalman(rho=0.8, sigma_v=0.5, sigma_e=0.6):
     """
-    Pooling-equilibrium state space from the QuantEcon lecture
+    Two-noisy-signals filter from section 37.5.3 of the QuantEcon lecture
     "Knowing the Forecasts of Others":
-    https://python-advanced.quantecon.org/knowing_forecasts_of_others.html
+    https://python-advanced.quantecon.org/knowing_forecasts_of_others.html#two-noisy-signals
 
-    The lecture sets H=None (no observation noise). Kalman.stationary_values
-    requires H, so a small diagonal H is added for numerical use only.
-    Use 1e-4 rather than smaller values to avoid singular-matrix errors in
-    scipy.linalg.inv on some platforms (e.g. Python 3.14 on CI).
+    State: theta_{t+1} = rho theta_t + v_t
+    Observations: w_t = [1, 1]' theta_t + [e_1t, e_2t]'
     """
-    beta, rho, b = 0.9, 0.8, 1.5
-    sigma_v, sigma_e = 0.5, 0.6
-
-    poly = np.array([1, -(1 + beta + b) / beta, 1 / beta])
-    roots_poly = np.roots(poly)
-    lambda_tilde, lambda_ = roots_poly.min(), roots_poly.max()
-
-    p = solve_discrete_riccati_scalar(rho, sigma_v, sigma_e)
-    kappa = rho * p / (p + sigma_e ** 2)
-    kappa_prod = kappa * sigma_e ** 2 / p
-
-    A = np.array([
-        [0., 0., 0., 0., 0., 0.],
-        [kappa / (lambda_ - rho), lambda_tilde, -kappa_prod / (lambda_ - rho),
-         0., rho / (lambda_ - rho), 0.],
-        [-kappa, 0., kappa_prod, 0., 0., 1.],
-        [b * kappa / (lambda_ - rho), b * lambda_tilde,
-         -b * kappa_prod / (lambda_ - rho), 0., b * rho / (lambda_ - rho) + rho, 1.],
-        [0., 0., 0., 0., rho, 1.],
-        [0., 0., 0., 0., 0., 0.],
-    ])
-    C = np.array([
-        [sigma_e, 0.],
-        [0., 0.],
-        [0., 0.],
-        [sigma_e, 0.],
-        [0., 0.],
-        [0., sigma_v],
-    ])
-    G = np.array([
-        [0., 0., 0., 1., 0., 0.],
-        [1., 0., 0., 0., 1., 0.],
-        [1., 0., 0., 0., 0., 0.],
-    ])
-    H = np.eye(G.shape[0]) * 1e-4
-
+    A = np.array([[rho]])
+    C = np.array([[np.sqrt(sigma_v)]])
+    G = np.array([[1.], [1.]])
+    H = np.eye(2) * sigma_e
     return Kalman(LinearStateSpace(A, C, G, H))
-
-
-def solve_discrete_riccati_scalar(rho, sigma_v, sigma_e):
-    """Stationary variance p from the lecture's scalar Riccati equation."""
-    return solve_discrete_riccati(
-        np.array([[rho]]),
-        np.array([[1.]]),
-        np.array([[sigma_v ** 2]]),
-        np.array([[sigma_e ** 2]]),
-        np.zeros((1, 1)),
-    ).item()
 
 
 def _expected_stationary_coefficients(kf, j, coeff_type):
@@ -219,10 +173,10 @@ class TestKalmanStationaryCoefficients:
             kf.stationary_coefficients(1, coeff_type='invalid')
 
 
-class TestKalmanStationaryCoefficientsKnowingForecasts:
+class TestKalmanStationaryCoefficientsTwoNoisySignals:
 
     def setup_method(self):
-        self.kf = _knowing_forecasts_of_others_kalman()
+        self.kf = _two_noisy_signals_kalman()
         self.methods = RICCATI_METHODS
 
     def test_stationary_coefficients_ma(self):
@@ -244,8 +198,9 @@ class TestKalmanStationaryCoefficientsKnowingForecasts:
                 _assert_coeff_lists_equal(actual, expected)
 
     def test_coefficients_are_not_diagonal(self):
-        """Sanity check: lecture matrices produce non-trivial coefficients."""
+        """Sanity check: (n, k) = (1, 2) model yields non-diagonal MA coefficients."""
         kf = self.kf
         kf.stationary_values()
         psi_1 = kf.stationary_coefficients(1, coeff_type='ma')[1]
+        assert psi_1.shape == (2, 2)
         assert not np.allclose(psi_1, np.diag(np.diag(psi_1)))

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -237,11 +237,3 @@ class TestKalmanStationaryCoefficientsTwoNoisySignals:
                 expected = _expected_stationary_coefficients(
                     A, G, self.K_ref, k, j, 'var')
                 _assert_coeff_lists_equal(actual, expected)
-
-    def test_coefficients_are_not_diagonal(self):
-        """Sanity check: (n, k) = (1, 2) model yields non-diagonal MA coefficients."""
-        expected = _expected_stationary_coefficients(
-            self.kf.ss.A, self.kf.ss.G, self.K_ref, self.kf.ss.k, 1, 'ma')
-        psi_1 = expected[1]
-        assert psi_1.shape == (2, 2)
-        assert not np.allclose(psi_1, np.diag(np.diag(psi_1)))

--- a/quantecon/tests/test_kalman.py
+++ b/quantecon/tests/test_kalman.py
@@ -3,6 +3,7 @@ Tests for the kalman.py
 
 """
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 from quantecon import LinearStateSpace
 from quantecon import Kalman
@@ -99,23 +100,22 @@ class TestKalmanStationaryCoefficients:
 
     @staticmethod
     def _expected_stationary_coefficients(kf, j, coeff_type):
-        """Reference implementation for stationary_coefficients."""
+        """Closed-form reference using matrix powers."""
         A, G = kf.ss.A, kf.ss.G
-        K_infinity = kf.K_infinity
-        coeffs = []
+        K = kf.K_infinity
         if coeff_type == 'ma':
-            coeffs.append(np.identity(kf.ss.k))
-            P_mat = A
-            P = np.identity(kf.ss.n)
+            coeffs = [np.identity(kf.ss.k)]
+            coeffs.extend(
+                G @ np.linalg.matrix_power(A, i) @ K for i in range(j)
+            )
         elif coeff_type == 'var':
-            coeffs.append(G @ K_infinity)
-            P_mat = A - (K_infinity @ G)
-            P = np.copy(P_mat)
+            phi = A - K @ G
+            coeffs = [G @ K]
+            coeffs.extend(
+                G @ np.linalg.matrix_power(phi, i) @ K for i in range(1, j + 1)
+            )
         else:
             raise ValueError("Unknown coefficient type")
-        for i in range(1, j + 1):
-            coeffs.append((G @ P) @ K_infinity)
-            P = P @ P_mat
         return coeffs
 
     @staticmethod
@@ -146,9 +146,5 @@ class TestKalmanStationaryCoefficients:
     def test_stationary_coefficients_invalid_type(self):
         kf = self.kf
         kf.stationary_values()
-        try:
+        with pytest.raises(ValueError, match="Unknown coefficient type"):
             kf.stationary_coefficients(1, coeff_type='invalid')
-        except ValueError as e:
-            assert str(e) == "Unknown coefficient type"
-        else:
-            raise AssertionError("Expected ValueError was not raised")


### PR DESCRIPTION
## Summary
- Add `TestKalmanStationaryCoefficients` to cover `Kalman.stationary_coefficients`
- Verify MA and VAR coefficient recursion against a reference implementation
- Exercise both Riccati solvers (`doubling`, `qz`) and invalid `coeff_type` handling

Closes #128

## Test plan
- [x] `pytest quantecon/tests/test_kalman.py -v`

Made with [Cursor](https://cursor.com)