### PR TITLE
TST: Relax rtol on IVP analytic-comparison tests for Windows CI

### DIFF
--- a/quantecon/tests/test_ivp.py
+++ b/quantecon/tests/test_ivp.py
@@ -214,7 +214,10 @@ def test_solve_fixed_trajectory():
     for integrator, numeric_solution in results.items():
         ti = numeric_solution[:, 0]
         analytic_solution = solow_analytic_solution(ti, k0, *valid_params)
-        np.testing.assert_allclose(numeric_solution, analytic_solution)
+        # rtol relaxed from the 1e-7 default to tolerate platform-specific
+        # floating-point differences near steady state (e.g. Windows CI)
+        np.testing.assert_allclose(numeric_solution, analytic_solution,
+                                   rtol=1e-6)
 
 
 def test_solve_variable_trajectory():
@@ -231,7 +234,8 @@ def test_solve_variable_trajectory():
         analytic_solution = solow_analytic_solution(ti, k0, *valid_params)
 
         # test accuracy of solution
-        np.testing.assert_allclose(numeric_solution, analytic_solution)
+        np.testing.assert_allclose(numeric_solution, analytic_solution,
+                                   rtol=1e-6)
 
         # test termination condition
         diff = numeric_solution[-1, 1] - solow_steady_state(*valid_params)
@@ -256,7 +260,10 @@ def test_interpolation():
         interp_solution = model.interpolate(numeric_solution, ti, k=3, ext=2)
 
         analytic_solution = solow_analytic_solution(ti, k0, *valid_params)
-        np.testing.assert_allclose(interp_solution, analytic_solution)
+        # rtol relaxed from the 1e-7 default to tolerate platform-specific
+        # floating-point differences near steady state (e.g. Windows CI)
+        np.testing.assert_allclose(interp_solution, analytic_solution,
+                                   rtol=1e-6)
 
 
 def test_compute_residual():

--- a/quantecon/tests/test_ivp.py
+++ b/quantecon/tests/test_ivp.py
@@ -233,7 +233,9 @@ def test_solve_variable_trajectory():
         ti = numeric_solution[:, 0]
         analytic_solution = solow_analytic_solution(ti, k0, *valid_params)
 
-        # test accuracy of solution
+        # test accuracy of solution; rtol relaxed from the 1e-7 default to
+        # tolerate platform-specific floating-point differences near steady
+        # state (e.g. Windows CI)
         np.testing.assert_allclose(numeric_solution, analytic_solution,
                                    rtol=1e-6)
 


### PR DESCRIPTION
## Problem

The `conda-build` workflow is failing on `main` ([run 28091698120](https://github.com/QuantEcon/QuantEcon.py/actions/runs/28091698120)). The only failing job is `tests (windows-latest, 3.13)`; all other OS/Python combinations and the NumPy v2 job pass.

Two tests in `quantecon/tests/test_ivp.py` fail:

- `test_solve_fixed_trajectory`
- `test_interpolation`

## Root cause

These are floating-point precision flakes, not a regression. Each compares the numeric ODE solution against the analytic Solow solution with `np.testing.assert_allclose`, which defaults to `rtol=1e-7`. On Windows / Python 3.13 the two diverge by a max **relative** difference of `1.14e-7` — barely over the threshold — and only at the trajectory tail near steady state (indices ~977–982).

Evidence it is platform-specific rather than a code bug:

- Reproduces only on `windows-latest` + Python 3.13; every other platform passes.
- The commit that surfaced it (#837) only touched Kalman tests, nothing in the IVP module.

## Fix

Relax `rtol` from the `1e-7` default to `1e-6` (≈9× headroom over the observed `1.14e-7`) on the three numeric-vs-analytic comparisons. `test_solve_variable_trajectory` was not in this failing run but performs the identical near-steady-state comparison and shares the same latent flake, so it is relaxed too.

This follows the established convention in this repo for handling Windows CI floating-point differences (see #667, #633).

Tests and the CI `flake8` check pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)