### PR TITLE
BUG: Fix DLE.compute_sequence under NumPy >= 2.4 (#839)

### DIFF
--- a/quantecon/_dle.py
+++ b/quantecon/_dle.py
@@ -211,17 +211,22 @@ class DLE(object):
         self.R1_Price = np.empty((ts_length + 1, 1))
         self.R2_Price = np.empty((ts_length + 1, 1))
         self.R5_Price = np.empty((ts_length + 1, 1))
+        # Hoist the loop-invariant terms out of the loop: ``e1 @ self.Mc`` and
+        # the matrix powers of ``self.A0`` do not depend on ``i``.
+        eMc = e1 @ self.Mc
+        A0_1 = np.linalg.matrix_power(self.A0, 1)
+        A0_2 = np.linalg.matrix_power(self.A0, 2)
+        A0_5 = np.linalg.matrix_power(self.A0, 5)
         # Each price expression evaluates to a size-1 array (``self.beta`` is a
-        # (1, 1) array and ``e1`` is a row vector). Extract the scalar with
+        # (1, 1) array and ``eMc`` is a row vector). Extract the scalar with
         # ``.item()`` before assigning: NumPy >= 2.4 raises instead of silently
         # converting an ``ndim > 0`` array to a scalar on assignment. See #839.
         for i in range(ts_length + 1):
-            self.R1_Price[i, 0] = (self.beta * e1 @ self.Mc @ np.linalg.matrix_power(
-                self.A0, 1) @ xp[:, i] / (e1 @ self.Mc @ xp[:, i])).item()
-            self.R2_Price[i, 0] = (self.beta**2 * (e1 @ self.Mc @
-                np.linalg.matrix_power(self.A0, 2) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])).item()
-            self.R5_Price[i, 0] = (self.beta**5 * (e1 @ self.Mc @
-                np.linalg.matrix_power(self.A0, 5) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])).item()
+            xi = xp[:, i]
+            denom = (eMc @ xi).item()
+            self.R1_Price[i, 0] = (self.beta * eMc @ A0_1 @ xi).item() / denom
+            self.R2_Price[i, 0] = (self.beta**2 * (eMc @ A0_2 @ xi)).item() / denom
+            self.R5_Price[i, 0] = (self.beta**5 * (eMc @ A0_5 @ xi)).item() / denom
 
         # === Gross rates of return on 1-period risk-free bonds === #
         self.R1_Gross = 1 / self.R1_Price

--- a/quantecon/_dle.py
+++ b/quantecon/_dle.py
@@ -211,13 +211,17 @@ class DLE(object):
         self.R1_Price = np.empty((ts_length + 1, 1))
         self.R2_Price = np.empty((ts_length + 1, 1))
         self.R5_Price = np.empty((ts_length + 1, 1))
+        # Each price expression evaluates to a size-1 array (``self.beta`` is a
+        # (1, 1) array and ``e1`` is a row vector). Extract the scalar with
+        # ``.item()`` before assigning: NumPy >= 2.4 raises instead of silently
+        # converting an ``ndim > 0`` array to a scalar on assignment. See #839.
         for i in range(ts_length + 1):
-            self.R1_Price[i, 0] = self.beta * e1 @ self.Mc @ np.linalg.matrix_power(
-                self.A0, 1) @ xp[:, i] / (e1 @ self.Mc @ xp[:, i])
-            self.R2_Price[i, 0] = self.beta**2 * (e1 @ self.Mc @
-                np.linalg.matrix_power(self.A0, 2) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])
-            self.R5_Price[i, 0] = self.beta**5 * (e1 @ self.Mc @
-                np.linalg.matrix_power(self.A0, 5) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])
+            self.R1_Price[i, 0] = (self.beta * e1 @ self.Mc @ np.linalg.matrix_power(
+                self.A0, 1) @ xp[:, i] / (e1 @ self.Mc @ xp[:, i])).item()
+            self.R2_Price[i, 0] = (self.beta**2 * (e1 @ self.Mc @
+                np.linalg.matrix_power(self.A0, 2) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])).item()
+            self.R5_Price[i, 0] = (self.beta**5 * (e1 @ self.Mc @
+                np.linalg.matrix_power(self.A0, 5) @ xp[:, i]) / (e1 @ self.Mc @ xp[:, i])).item()
 
         # === Gross rates of return on 1-period risk-free bonds === #
         self.R1_Gross = 1 / self.R1_Price
@@ -239,12 +243,14 @@ class DLE(object):
             self.Pay_Price = np.empty((ts_length + 1, 1))
             self.Pay_Gross = np.empty((ts_length + 1, 1))
             self.Pay_Gross[0, 0] = np.nan
+            # As above, coerce each size-1 result to a scalar with ``.item()``
+            # so assignment works under NumPy >= 2.4. See #839.
             for i in range(ts_length + 1):
-                self.Pay_Price[i, 0] = (xp[:, i].T @ self.Q @
-                    xp[:, i] + self.q) / (e1 @ self.Mc @ xp[:, i])
+                self.Pay_Price[i, 0] = ((xp[:, i].T @ self.Q @
+                    xp[:, i] + self.q) / (e1 @ self.Mc @ xp[:, i])).item()
             for i in range(ts_length):
-                self.Pay_Gross[i + 1, 0] = self.Pay_Price[i + 1,
-                                                          0] / (self.Pay_Price[i, 0] - Pay @ xp[:, i])
+                self.Pay_Gross[i + 1, 0] = (self.Pay_Price[i + 1,
+                    0] / (self.Pay_Price[i, 0] - Pay @ xp[:, i])).item()
         return
 
     def irf(self, ts_length=100, shock=None):

--- a/quantecon/_dle.py
+++ b/quantecon/_dle.py
@@ -218,15 +218,19 @@ class DLE(object):
         A0_2 = np.linalg.matrix_power(self.A0, 2)
         A0_5 = np.linalg.matrix_power(self.A0, 5)
         # Each price expression evaluates to a size-1 array (``self.beta`` is a
-        # (1, 1) array and ``eMc`` is a row vector). Extract the scalar with
-        # ``.item()`` before assigning: NumPy >= 2.4 raises instead of silently
-        # converting an ``ndim > 0`` array to a scalar on assignment. See #839.
+        # (1, 1) array and ``eMc`` is a row vector). Coerce the size-1 result to
+        # a scalar with ``.item()`` *after* dividing, so assignment works under
+        # NumPy >= 2.4 (which raises instead of silently converting an
+        # ``ndim > 0`` array to a scalar on assignment). Keeping the division
+        # inside NumPy preserves the pre-2.4 behaviour when ``denom == 0`` (an
+        # ``inf``/``nan`` with a warning, rather than a ``ZeroDivisionError``).
+        # See #839.
         for i in range(ts_length + 1):
             xi = xp[:, i]
-            denom = (eMc @ xi).item()
-            self.R1_Price[i, 0] = (self.beta * eMc @ A0_1 @ xi).item() / denom
-            self.R2_Price[i, 0] = (self.beta**2 * (eMc @ A0_2 @ xi)).item() / denom
-            self.R5_Price[i, 0] = (self.beta**5 * (eMc @ A0_5 @ xi)).item() / denom
+            denom = eMc @ xi
+            self.R1_Price[i, 0] = (self.beta * eMc @ A0_1 @ xi / denom).item()
+            self.R2_Price[i, 0] = (self.beta**2 * (eMc @ A0_2 @ xi) / denom).item()
+            self.R5_Price[i, 0] = (self.beta**5 * (eMc @ A0_5 @ xi) / denom).item()
 
         # === Gross rates of return on 1-period risk-free bonds === #
         self.R1_Gross = 1 / self.R1_Price

--- a/quantecon/tests/test_dle.py
+++ b/quantecon/tests/test_dle.py
@@ -109,3 +109,39 @@ class TestDLE:
         for item in solutions.keys():
             assert_allclose(self.dle.__dict__[
                             item], solutions[item], atol=ATOL)
+
+    def test_compute_sequence(self):
+        # Regression test for GH #839: the asset-price terms evaluate to
+        # size-1 arrays, and assigning them into the scalar price slots used to
+        # rely on NumPy implicitly converting an ``ndim > 0`` array to a scalar.
+        # NumPy >= 2.4 raises instead, so ``compute_sequence`` must coerce the
+        # values with ``.item()``.
+        x0 = np.array([[5], [150], [1], [0], [0]])
+        ts_length = 10
+        self.dle.compute_sequence(x0, ts_length=ts_length)
+
+        for name in ('R1_Price', 'R2_Price', 'R5_Price'):
+            price = self.dle.__dict__[name]
+            assert price.shape == (ts_length + 1, 1)
+            assert np.all(np.isfinite(price))
+
+        beta = 1 / 1.05
+        # At t=0 the J-period risk-free prices reduce to the closed form beta**J
+        assert_allclose(self.dle.R1_Price[0, 0], beta, atol=ATOL)
+        assert_allclose(self.dle.R2_Price[0, 0], beta ** 2, atol=ATOL)
+        assert_allclose(self.dle.R5_Price[0, 0], beta ** 5, atol=ATOL)
+
+    def test_compute_sequence_with_pay(self):
+        # The ``Pay`` branch of compute_sequence has the same size-1 assignment
+        # pattern as the risk-free price terms (GH #839); make sure it runs and
+        # populates the Pay_Price / Pay_Gross paths with finite values.
+        x0 = np.array([[5], [150], [1], [0], [0]])
+        ts_length = 10
+        Pay = np.array([[1., 0., 0., 0., 0.]])
+        self.dle.compute_sequence(x0, ts_length=ts_length, Pay=Pay)
+
+        assert self.dle.Pay_Price.shape == (ts_length + 1, 1)
+        assert self.dle.Pay_Gross.shape == (ts_length + 1, 1)
+        assert np.all(np.isfinite(self.dle.Pay_Price))
+        # Pay_Gross[0, 0] is intentionally set to nan; the rest must be finite
+        assert np.all(np.isfinite(self.dle.Pay_Gross[1:]))


### PR DESCRIPTION
## Summary

Fixes #839. `DLE.compute_sequence` raises under **NumPy 2.4** when it computes the asset-price terms `R1_Price`, `R2_Price`, `R5_Price`. The same code runs under NumPy 2.3.x, so this is a 2.3 → 2.4 regression.

## Root cause

Each price expression evaluates to a **size-1 array**, not a Python scalar: `self.beta` is a `(1, 1)` array and `e1` is a row vector, so the matmul chain reduces to shape `(1,)` or `(1, 1)`. Assigning such an array into a scalar slot like `self.R1_Price[i, 0]` used to work because NumPy silently converted a size-1 `ndim > 0` array to a scalar. That conversion was deprecated in NumPy 1.25 and became a hard error in NumPy 2.4 (listed under *Expired deprecations* in the [2.4.0 release notes](https://numpy.org/doc/2.4/release/2.4.0-notes.html)), so the assignment now raises `ValueError: setting an array element with a sequence` (underlying `TypeError: only 0-dimensional arrays can be converted to Python scalars`).

## Fix

Coerce each price expression to a scalar with `.item()` before assignment. This works regardless of the intermediate shape and reproduces the pre-2.4 values exactly.

Note: redefining `e1` as 1-D (suggested in the issue discussion) is **not sufficient on its own** — because `self.beta` is itself a `(1, 1)` array, `self.beta * e1 @ …` re-introduces a 2-D shape and the result stays `ndim > 0`. I verified this empirically: under both the current 2-D `e1` and the proposed 1-D `e1`, `R1` is shape `(1,)` and `R2`/`R5` are shape `(1, 1)`. `.item()` addresses the conversion at the point of assignment and is robust to all of these shapes.

The same size-1 assignment pattern also exists in the optional `Pay` branch (`Pay_Price` / `Pay_Gross`), which is only reached when a `Pay` array is passed. It is fixed here too, so `compute_sequence` is robust regardless of arguments.

## Verification

The validated MWE from the issue (Hall's permanent-income economy) now runs, and the `.item()` path reproduces the pre-regression values exactly:

| numpy | before this PR | after this PR |
| --- | --- | --- |
| 2.3.5 | ✅ runs — `R1_Price[:3] = [0.95238095, …]` | ✅ runs — identical values |
| 2.4.6 | ❌ raises | ✅ runs — identical values |

## Tests

`compute_sequence` previously had **no test coverage**. This PR adds two regression tests to `TestDLE`:

- `test_compute_sequence` — exercises the default (risk-free price) path, checks shapes and finiteness, and anchors `R1/R2/R5_Price[0, 0]` to the closed form `β**J` at `t = 0`.
- `test_compute_sequence_with_pay` — exercises the `Pay` branch (`Pay_Price` / `Pay_Gross`).

All 10 tests in `quantecon/tests/test_dle.py` pass locally (NumPy 2.3.5, Python 3.13).

## Downstream impact

This unblocks 5 lectures in `lecture-python-advanced.myst` under `anaconda=2026.06` (numpy 2.4.6): `cattle_cycles`, `growth_in_dles`, `irfs_in_hall_model`, `lucas_asset_pricing_dles`, `permanent_income_dles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)