### PR TITLE
CI: De-flake coverage upload and stop fail-fast cancelling the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,11 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
-      # Don't let one job's failure (e.g. a flaky timing test or a transient
-      # coverage-upload error) cancel the rest of the matrix.
+      # one failing job shouldn't cancel the rest of the matrix
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        # Quote the versions so they are unambiguously strings: bare YAML
-        # numbers are brittle (e.g. 3.10 would parse as 3.1) and make the
-        # ``matrix.python-version == '3.13'`` gate below unreliable.
+        # quoted as strings (bare 3.10 would parse as float 3.1)
         python-version: ["3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
@@ -60,14 +57,9 @@ jobs:
         coverage run -m pytest quantecon
         coverage lcov
     - name: Coveralls
-      # Pin to a major release tag (matching the other actions in this file)
-      # rather than @master, for reproducibility and supply-chain safety.
       uses: coverallsapp/github-action@v2
-      # Upload coverage from a single Linux job only. When several jobs report
-      # to the same Coveralls build without parallel coordination, whichever
-      # job finishes after the build is closed gets a 422 ("Build is already
-      # closed") and fails. ``continue-on-error`` additionally keeps a Coveralls
-      # outage from blocking a merge.
+      # upload from one Linux job only (avoids the Coveralls parallel-build 422
+      # race); continue-on-error so an upload hiccup can't fail CI
       if: runner.os == 'Linux' && matrix.python-version == '3.13'
       continue-on-error: true
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.12, 3.13, 3.14]
+        # Quote the versions so they are unambiguously strings: bare YAML
+        # numbers are brittle (e.g. 3.10 would parse as 3.1) and make the
+        # ``matrix.python-version == '3.13'`` gate below unreliable.
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
       with:
@@ -57,7 +60,9 @@ jobs:
         coverage run -m pytest quantecon
         coverage lcov
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      # Pin to a major release tag (matching the other actions in this file)
+      # rather than @master, for reproducibility and supply-chain safety.
+      uses: coverallsapp/github-action@v2
       # Upload coverage from a single Linux job only. When several jobs report
       # to the same Coveralls build without parallel coordination, whichever
       # job finishes after the build is closed gets a 422 ("Build is already

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let one job's failure (e.g. a flaky timing test or a transient
+      # coverage-upload error) cancel the rest of the matrix.
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.12, 3.13, 3.14]
@@ -55,7 +58,13 @@ jobs:
         coverage lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master
-      if: runner.os == 'Linux'
+      # Upload coverage from a single Linux job only. When several jobs report
+      # to the same Coveralls build without parallel coordination, whichever
+      # job finishes after the build is closed gets a 422 ("Build is already
+      # closed") and fails. ``continue-on-error`` additionally keeps a Coveralls
+      # outage from blocking a merge.
+      if: runner.os == 'Linux' && matrix.python-version == '3.13'
+      continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
       continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+        # `file` (not the deprecated `path-to-lcov`) is the v2 input
+        file: coverage.lcov
+        format: lcov
 
   publish:
 


### PR DESCRIPTION
## Summary

CI has been going red on **green code**. Investigating the failure on #842 (and the matching failures on recent `main` pushes) turned up two independent, pre-existing infra problems — neither is a real test or code failure. This PR hardens the workflow against both.

## Problem 1 — Coveralls 422 race

The `Coveralls` step runs on **all three** Linux matrix jobs (`if: runner.os == 'Linux'`) and each uploads to the *same* Coveralls build with no parallel coordination. Whichever Linux job reports after the build has been closed gets:

> `422 Can't add a job to a build that is already closed. Build … is closed.`

On the #842 run, `ubuntu-3.14` finished first and closed the build; `ubuntu-3.13` reported a minute later → 422 → job failed. Its pytest step had already passed. This is timing-dependent and intermittent — earlier runs on the same branch were green.

## Problem 2 — `fail-fast` cascade

The matrix had no `fail-fast` key, so it defaulted to `true`. The moment one job failed (the 422 above, or the flaky timing test below), GitHub **cancelled every other in-progress job** — so a single flake painted the whole 9-job matrix red, with most jobs showing `cancelled` rather than their real result.

## Fix

| Change | Effect |
| --- | --- |
| Upload coverage from a single Linux job (`matrix.python-version == '3.13'`) | Only one job reports to Coveralls, so there is no build-already-closed race. |
| `continue-on-error: true` on the Coveralls step | A Coveralls outage records a warning instead of failing the job / blocking a merge. |
| `fail-fast: false` on the matrix | Jobs run to completion independently; one flaky job no longer cancels the others, and the dashboard shows each job's true result. |

Coverage is unaffected in practice — this is a pure-Python library, so line coverage does not vary across OS/Python, and one uploader is sufficient.

## Note: a separate flaky test (not fixed here)

While diagnosing this I found that recent `main` failures were caused by a different flake — a wall-clock timing assertion, `quantecon/util/tests/test_timing.py::TestTimer::test_timeit_lambda_function`, which overshoots on a slow runner (`ACTUAL 0.207` vs `DESIRED 0.05`, `rtol=2`). With `fail-fast: false` that flake will no longer cancel the rest of the matrix, but the test itself can still go red on an unlucky runner. Tightening or de-timing that test is left as a follow-up so this PR stays focused on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
