### PR TITLE
TEST: De-flake timing tests with lower-bound assertions

### DIFF
--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -26,6 +26,28 @@ def assert_at_least(measured, expected):
         f"({TIMING_LOWER_BOUND:g} * expected {expected:.4f}s)")
 
 
+# Above this multiple of the expected sleep, a measurement can only be a unit
+# bug (``elapsed`` stored in ms/µs is ~1000x/1e6x larger), not scheduler
+# overshoot (a few x at most), so the ceiling separates the two without flaking.
+TIMING_UNIT_CEILING = 100
+
+
+def assert_in_seconds(measured, expected):
+    """Assert ``measured`` is in seconds (~``expected``), not a larger unit.
+
+    Lower bound: the timer did not under-report. Upper bound: a ceiling no real
+    ``expected``-second sleep can reach, but which a unit leak into
+    ``Timer.elapsed`` (ms/µs) always trips -- the invariant the unit tests
+    guard.
+    """
+    lower_bound = expected * TIMING_LOWER_BOUND
+    upper_bound = expected * TIMING_UNIT_CEILING
+    assert lower_bound <= measured < upper_bound, (
+        f"measured {measured:.4f}s is outside the seconds range "
+        f"[{lower_bound:.4f}, {upper_bound:.4f}) around expected {expected:.4f}s "
+        f"(did the display unit leak into elapsed?)")
+
+
 class TestTicTacToc:
     def setup_method(self):
         self.h = 0.1
@@ -99,16 +121,16 @@ class TestTimer:
         with Timer(verbose=False) as timer_sec:
             time.sleep(self.sleep_time)
         expected_sec = self.sleep_time
-        assert_at_least(timer_sec.elapsed, expected_sec)
+        assert_in_seconds(timer_sec.elapsed, expected_sec)
         
         # Timer always stores elapsed time in seconds regardless of display unit
         with Timer(unit="milliseconds", verbose=False) as timer_ms:
             time.sleep(self.sleep_time)
-        assert_at_least(timer_ms.elapsed, expected_sec)
+        assert_in_seconds(timer_ms.elapsed, expected_sec)
         
         with Timer(unit="microseconds", verbose=False) as timer_us:
             time.sleep(self.sleep_time)
-        assert_at_least(timer_us.elapsed, expected_sec)
+        assert_in_seconds(timer_us.elapsed, expected_sec)
         
     def test_invalid_unit(self):
         """Test that invalid units raise ValueError."""
@@ -248,9 +270,9 @@ class TestTimer:
         
         # All results should be in seconds regardless of display unit
         for run_time in result_ms['elapsed']:
-            assert_at_least(run_time, self.sleep_time)
+            assert_in_seconds(run_time, self.sleep_time)
         for run_time in result_us['elapsed']:
-            assert_at_least(run_time, self.sleep_time)
+            assert_in_seconds(run_time, self.sleep_time)
 
     def test_timeit_stats_only(self):
         """Test timeit with stats_only option."""

--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -20,8 +20,10 @@ TIMING_LOWER_BOUND = 0.9
 
 def assert_at_least(measured, expected):
     """Assert ``measured`` seconds is not meaningfully below ``expected``."""
-    assert measured >= expected * TIMING_LOWER_BOUND, (
-        f"measured {measured}s is well below the expected ~{expected}s sleep")
+    lower_bound = expected * TIMING_LOWER_BOUND
+    assert measured >= lower_bound, (
+        f"measured {measured:.4f}s is below the lower bound {lower_bound:.4f}s "
+        f"({TIMING_LOWER_BOUND:g} * expected {expected:.4f}s)")
 
 
 class TestTicTacToc:

--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -4,9 +4,24 @@ Tests for timing.py
 """
 
 import time
-from numpy.testing import assert_allclose, assert_
+from numpy.testing import assert_
 from quantecon.util import tic, tac, toc, loop_timer, Timer, timeit
 import quantecon as qe
+
+
+# ``time.sleep(t)`` only guarantees the process is suspended for *at least*
+# ``t`` seconds -- a busy or descheduled CI runner can make the measured time
+# arbitrarily larger. The timing tests below therefore assert only a lower
+# bound (that the timing utilities do not under-report the elapsed time) rather
+# than an upper bound on wall-clock duration, which is inherently flaky on
+# shared CI runners. See the discussion in GH #845.
+TIMING_LOWER_BOUND = 0.9
+
+
+def assert_at_least(measured, expected):
+    """Assert ``measured`` seconds is not meaningfully below ``expected``."""
+    assert measured >= expected * TIMING_LOWER_BOUND, (
+        f"measured {measured}s is well below the expected ~{expected}s sleep")
 
 
 class TestTicTacToc:
@@ -27,12 +42,9 @@ class TestTicTacToc:
         time.sleep(self.h)
         tm3 = toc()
 
-        rtol = 2
-        atol = 0.05
-
         for actual, desired in zip([tm1, tm2, tm3],
                                    [self.h, self.h, self.h*3]):
-            assert_allclose(actual, desired, atol=atol, rtol=rtol)
+            assert_at_least(actual, desired)
 
     def test_loop(self):
 
@@ -47,13 +59,10 @@ class TestTicTacToc:
         test_two_arg = \
             loop_timer(5, test_function_two_arg, [self.h, 1], digits=10)
 
-        rtol = 2
-        atol = 0.05
-
         for tm in test_one_arg:
-            assert_allclose(tm, self.h, atol=atol, rtol=rtol)
+            assert_at_least(tm, self.h)
         for tm in test_two_arg:
-            assert_allclose(tm, self.h, atol=atol, rtol=rtol)
+            assert_at_least(tm, self.h)
 
         for (average_time, average_of_best) in [test_one_arg, test_two_arg]:
             assert_(average_time >= average_of_best)
@@ -72,7 +81,7 @@ class TestTimer:
             
         # Check that elapsed time was recorded
         assert timer.elapsed is not None
-        assert_allclose(timer.elapsed, self.sleep_time, atol=0.05, rtol=2)
+        assert_at_least(timer.elapsed, self.sleep_time)
         
     def test_timer_return_value(self):
         """Test that Timer returns self for variable assignment."""
@@ -80,7 +89,7 @@ class TestTimer:
             time.sleep(self.sleep_time)
             
         assert timer.elapsed is not None
-        assert_allclose(timer.elapsed, self.sleep_time, atol=0.05, rtol=2)
+        assert_at_least(timer.elapsed, self.sleep_time)
         
     def test_timer_units(self):
         """Test different time units."""
@@ -88,16 +97,16 @@ class TestTimer:
         with Timer(verbose=False) as timer_sec:
             time.sleep(self.sleep_time)
         expected_sec = self.sleep_time
-        assert_allclose(timer_sec.elapsed, expected_sec, atol=0.05, rtol=2)
+        assert_at_least(timer_sec.elapsed, expected_sec)
         
         # Timer always stores elapsed time in seconds regardless of display unit
         with Timer(unit="milliseconds", verbose=False) as timer_ms:
             time.sleep(self.sleep_time)
-        assert_allclose(timer_ms.elapsed, expected_sec, atol=0.05, rtol=2)
+        assert_at_least(timer_ms.elapsed, expected_sec)
         
         with Timer(unit="microseconds", verbose=False) as timer_us:
             time.sleep(self.sleep_time)
-        assert_allclose(timer_us.elapsed, expected_sec, atol=0.05, rtol=2)
+        assert_at_least(timer_us.elapsed, expected_sec)
         
     def test_invalid_unit(self):
         """Test that invalid units raise ValueError."""
@@ -147,7 +156,7 @@ class TestTimer:
             
         # Timer should still record elapsed time
         assert timer.elapsed is not None
-        assert_allclose(timer.elapsed, self.sleep_time, atol=0.05, rtol=2)
+        assert_at_least(timer.elapsed, self.sleep_time)
 
     def test_timeit_basic(self):
         """Test basic timeit functionality."""
@@ -166,9 +175,9 @@ class TestTimer:
         
         # Check timing accuracy
         for run_time in result['elapsed']:
-            assert_allclose(run_time, self.sleep_time, atol=0.05, rtol=2)
+            assert_at_least(run_time, self.sleep_time)
             
-        assert_allclose(result['average'], self.sleep_time, atol=0.05, rtol=2)
+        assert_at_least(result['average'], self.sleep_time)
         assert result['minimum'] <= result['average'] <= result['maximum']
 
     def test_timeit_lambda_function(self):
@@ -183,7 +192,7 @@ class TestTimer:
         # Check results
         assert len(result['elapsed']) == 2
         for run_time in result['elapsed']:
-            assert_allclose(run_time, self.sleep_time * 0.5, atol=0.05, rtol=2)
+            assert_at_least(run_time, self.sleep_time * 0.5)
 
     def test_timeit_validation(self):
         """Test validation for timeit function."""
@@ -237,9 +246,9 @@ class TestTimer:
         
         # All results should be in seconds regardless of display unit
         for run_time in result_ms['elapsed']:
-            assert_allclose(run_time, self.sleep_time, atol=0.05, rtol=2)
+            assert_at_least(run_time, self.sleep_time)
         for run_time in result_us['elapsed']:
-            assert_allclose(run_time, self.sleep_time, atol=0.05, rtol=2)
+            assert_at_least(run_time, self.sleep_time)
 
     def test_timeit_stats_only(self):
         """Test timeit with stats_only option."""

--- a/quantecon/util/tests/test_timing.py
+++ b/quantecon/util/tests/test_timing.py
@@ -26,19 +26,20 @@ def assert_at_least(measured, expected):
         f"({TIMING_LOWER_BOUND:g} * expected {expected:.4f}s)")
 
 
-# Above this multiple of the expected sleep, a measurement can only be a unit
-# bug (``elapsed`` stored in ms/µs is ~1000x/1e6x larger), not scheduler
-# overshoot (a few x at most), so the ceiling separates the two without flaking.
+# A measurement above this multiple of the expected sleep is far more likely a
+# unit bug (``elapsed`` stored in ms/µs is ~1000x/1e6x larger) than scheduler
+# overshoot, which is unbounded in theory but a few x at most under normal CI
+# scheduling. The ceiling separates the two with negligible flake risk.
 TIMING_UNIT_CEILING = 100
 
 
 def assert_in_seconds(measured, expected):
     """Assert ``measured`` is in seconds (~``expected``), not a larger unit.
 
-    Lower bound: the timer did not under-report. Upper bound: a ceiling no real
-    ``expected``-second sleep can reach, but which a unit leak into
-    ``Timer.elapsed`` (ms/µs) always trips -- the invariant the unit tests
-    guard.
+    Lower bound: the timer did not under-report. Upper bound: a ceiling not
+    expected to be reached by an ``expected``-second sleep under normal CI
+    scheduling, but which a unit leak into ``Timer.elapsed`` (ms/µs) always
+    trips -- the invariant the unit tests guard.
     """
     lower_bound = expected * TIMING_LOWER_BOUND
     upper_bound = expected * TIMING_UNIT_CEILING


### PR DESCRIPTION
## Summary

Fixes the flaky timing tests that have been intermittently reddening CI on green code (twice on `main`, once on #845). This is the second of the two root causes found while investigating #842's CI failure — the first (Coveralls 422 race + `fail-fast` cascade) is addressed in #845.

## Root cause

The whole `test_timing.py` suite verifies the timing utilities (`tic/tac/toc`, `loop_timer`, `Timer`, `timeit`) by sleeping for a known duration and asserting the *measured* time stays within an **upper** bound:

> `assert_allclose(measured, expected_sleep, atol=0.05, rtol=2)`

That is the wrong invariant for wall-clock timing. `time.sleep(t)` only guarantees the process is suspended for *at least* `t` seconds; a busy or descheduled CI runner can make the measured time arbitrarily larger. The tightest case, `test_timeit_lambda_function` (expected ≈ 0.05 s, ceiling ≈ 0.20 s), is the one that keeps tripping — e.g. measured `0.207 s` vs ceiling `0.20 s` on a loaded macOS runner.

## Fix

Replace the ~14 upper-bound assertions with a lower-bound check, `assert_at_least(measured, expected)`, which asserts the utilities **do not under-report** elapsed time (`measured >= expected * 0.9`). Scheduler overshoot — the actual source of the flakiness — is no longer treated as a failure, while a genuinely broken timer (returning zero / far too little) is still caught.

| Kept as-is | Why |
| --- | --- |
| `assert result['minimum'] <= result['average'] <= result['maximum']` | A relationship invariant, not wall-clock dependent. |
| `assert_(average_time >= average_of_best)` | Same — relationship between aggregates. |
| `test_timeit_single_run` exact-equality asserts | Compare fields to each other, not to absolute time. |

The now-unused `assert_allclose` import and the dead `rtol`/`atol` locals are removed (keeps the CI `flake8 --select F401` check green).

## Verification

- `flake8 --select F401,F405,E231 quantecon/util/tests/test_timing.py` — clean.
- `pytest quantecon/util/tests/test_timing.py` — **27 passed**, run repeatedly with stable results.

## Relationship to the other PRs

- #845 stops a single flake from cancelling the whole matrix (`fail-fast: false`) and removes the Coveralls race; this PR removes the flake itself. Together they should make CI reliably green.
- #842 (the DLE / NumPy 2.4 fix that started this) is functionally green; it just needs #845's hardened workflow once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
