### PR TITLE
FIX: Fix premature convergence in AS equilibrium_payoffs

### DIFF
--- a/quantecon/game_theory/repeated_game.py
+++ b/quantecon/game_theory/repeated_game.py
@@ -189,7 +189,10 @@ def _equilibrium_payoffs_abreu_sannikov(rpg, tol=1e-12, max_iter=500,
         u_old = np.copy(u)
         _update_u(u, W_new[:n_new_pt])
 
-        # check convergence
+        # check convergence; u is updated only by assignment from payoff
+        # values in _update_u, so exact comparison is appropriate, and
+        # stopping while u is still moving by sub-tol amounts can leave
+        # near-duplicate vertices in the hull
         if n_new_pt == n_old_pt and np.array_equal(u, u_old):
             if np.linalg.norm(W_new[:n_new_pt] - W_old[:n_new_pt]) < tol:
                 break

--- a/quantecon/game_theory/repeated_game.py
+++ b/quantecon/game_theory/repeated_game.py
@@ -60,7 +60,9 @@ class RepeatedGame:
                 max_iter : scalar(int)
                     Maximum number of iterations.
                 u_init : ndarray(float, ndim=1)
-                    The initial guess of threat points.
+                    The initial guess of threat points. By default, the
+                    minimum payoff of each player is used. A supplied
+                    guess is clipped from below by the minimum payoffs.
         
         Returns
         -------
@@ -88,7 +90,7 @@ class RepeatedGame:
 
 
 def _equilibrium_payoffs_abreu_sannikov(rpg, tol=1e-12, max_iter=500,
-                                        u_init=np.zeros(2)):
+                                        u_init=None):
     """
     Using 'abreu_sannikov' algorithm to compute the set of payoff pairs
     of all pure-strategy subgame-perfect equilibria with public randomization
@@ -106,8 +108,11 @@ def _equilibrium_payoffs_abreu_sannikov(rpg, tol=1e-12, max_iter=500,
     max_iter : scalar(int), optional(default=500)
         Maximum number of iterations.
 
-    u_init : ndarray(float, ndim=1), optional(default=np.zeros(2))
-        The initial guess of threat points.
+    u_init : ndarray(float, ndim=1), optional
+        The initial guess of threat points. It must not exceed the
+        threat points of the equilibrium payoff set. By default, the
+        minimum payoff of each player is used. A supplied guess is
+        clipped from below by the minimum payoffs.
 
     Returns
     -------
@@ -142,8 +147,14 @@ def _equilibrium_payoffs_abreu_sannikov(rpg, tol=1e-12, max_iter=500,
     # count the new points generated in each iteration
     n_new_pt = 0
 
-    # copy the threat points
-    u = np.copy(u_init)
+    # initial threat points: the minimum payoffs by default; a supplied
+    # guess is clipped from below by the minimum payoffs
+    payoff_mins = np.array([sg.payoff_arrays[0].min(),
+                            sg.payoff_arrays[1].min()], dtype=float)
+    if u_init is None:
+        u = payoff_mins
+    else:
+        u = np.maximum(np.asarray(u_init, dtype=float), payoff_mins)
 
     # initialization
     payoff_pts = \
@@ -163,17 +174,25 @@ def _equilibrium_payoffs_abreu_sannikov(rpg, tol=1e-12, max_iter=500,
                hull.equations, u, IC, action_profile_payoff,
                extended_payoff, new_pts, W_new)
 
+        if n_new_pt == 0:
+            msg = ("no incentive-compatible payoff vector found; the game "
+                   "may have no pure-action subgame perfect equilibrium "
+                   "for this value of delta")
+            raise ValueError(msg)
+
         n_iter += 1
         if n_iter >= max_iter:
             break
 
+        # update threat points; done before the convergence check, since
+        # the set has not converged while the threat points are moving
+        u_old = np.copy(u)
+        _update_u(u, W_new[:n_new_pt])
+
         # check convergence
-        if n_new_pt == n_old_pt:
+        if n_new_pt == n_old_pt and np.array_equal(u, u_old):
             if np.linalg.norm(W_new[:n_new_pt] - W_old[:n_new_pt]) < tol:
                 break
-
-        # update threat points
-        _update_u(u, W_new[:n_new_pt])
 
     hull = ConvexHull(W_new[:n_new_pt])
 

--- a/quantecon/game_theory/tests/test_repeated_game.py
+++ b/quantecon/game_theory/tests/test_repeated_game.py
@@ -3,6 +3,7 @@ Tests for repeated_game.py
 
 """
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 from quantecon.game_theory import NormalFormGame, RepeatedGame
 
@@ -47,3 +48,25 @@ class TestAS():
                 hull = rpg.equilibrium_payoffs(method=method,
                                                options={'u_init': d['u']})
                 assert_allclose(hull.points[hull.vertices], d['vertices'])
+
+    def test_abreu_sannikov_default_u_init(self):
+        for d in self.game_dicts:
+            rpg = RepeatedGame(d['sg'], d['delta'])
+            hull = rpg.equilibrium_payoffs()
+            assert_allclose(hull.points[hull.vertices], d['vertices'])
+
+    def test_abreu_sannikov_low_u_init(self):
+        # A u_init below the threat points must not stop the iteration
+        # before the first threat point update
+        for d in self.game_dicts:
+            rpg = RepeatedGame(d['sg'], d['delta'])
+            hull = rpg.equilibrium_payoffs(options={'u_init': np.zeros(2)})
+            assert_allclose(hull.points[hull.vertices], d['vertices'])
+
+    def test_abreu_sannikov_no_pure_action_spe(self):
+        # Game with no pure-action subgame perfect equilibrium at low delta
+        bimatrix = [[(1, -1), (-1, 2)],
+                    [(-2, 2), (1, 0)]]
+        rpg = RepeatedGame(NormalFormGame(bimatrix), 0.05)
+        with pytest.raises(ValueError):
+            rpg.equilibrium_payoffs()


### PR DESCRIPTION
This PR fixes a bug in the Abreu–Sannikov algorithm in `RepeatedGame.equilibrium_payoffs` that could make it return the *feasible* payoff hull instead of the equilibrium payoff set under the default options.

## The bug

```python
import numpy as np
from quantecon.game_theory import NormalFormGame, RepeatedGame

bimatrix = [[(9, 9), (1, 10)], [(10, 1), (3, 3)]]  # Prisoner's Dilemma
hull = RepeatedGame(NormalFormGame(bimatrix), 0.75).equilibrium_payoffs()
print(hull.points[hull.vertices])
```

This returns the vertices of the feasible payoff hull, `[[9, 9], [1, 10], [3, 3], [10, 1]]`, whereas the correct equilibrium payoff set is the quadrilateral with vertices `[[3, 3], [9.75, 3], [9, 9], [3, 9.75]]`.

Cause: `u_init` defaults to `np.zeros(2)`, and `_update_u` runs only *after* the convergence check. Whenever no IC constraint binds against `u_init` at the first iteration (which holds whenever every stage payoff exceeds `u_init + best_dev_gain`, as in any game with payoffs sufficiently above zero), `_R` reproduces the initial payoff points exactly, so `W_new == W_old` and the loop exits before the threat points are ever updated. The existing test passed `u_init` explicitly for both test games, which is how the bug stayed hidden.

## The fix

- `u_init` now defaults to the minimum payoff of each player (the initialization in Abreu and Sannikov (2014)), and a supplied guess is clipped from below by the minimum payoffs. This also fixes the uninformative `ValueError: zero-size array to reduction operation minimum` previously raised for games with all-negative payoffs under the zeros default.
- The threat points are updated *before* the convergence check, and convergence additionally requires them to be unchanged, so that a stationary `W` with still-moving threat points is not reported as converged. This protects the case of an explicitly supplied low `u_init` independently of the new default.
- An empty candidate set now raises an informative `ValueError` (the game may have no pure-action subgame perfect equilibrium for the given discount factor) instead of failing further down.

## Tests

- The default and a low (`np.zeros(2)`) `u_init` now reproduce the known equilibrium payoff sets of both the Abreu–Sannikov (2014) example and the Prisoner's Dilemma; the zeros/PD case is the exact regression above.
- The informative error is tested on a non-zero-sum game with no pure Nash equilibrium at a low discount factor.
- Results were cross-checked against the independent implementation in QuantEcon/GameTheory.jl and, for one case with a fragile geometry, against a 256-bit `BigFloat` reference computation; with the corrected initialization the two implementations agree.

Not addressed here (a separate, pre-existing limitation): `scipy.spatial.ConvexHull` raises `QhullError` when the payoff set or an iterate is degenerate (segment- or point-shaped, e.g. for zero-sum or common-interest stage games), since Qhull requires full-dimensional input.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
