### PR TITLE
CI: Fix flake8 --select so E231/F405 are actually enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: flake8 Tests
       shell: bash -l {0}
       run: |
-        flake8 --select F401, F405, E231 quantecon
+        flake8 --select=F401,F405,E231 quantecon
     - name: Run Tests (pytest)
       shell: bash -l {0}
       run: |

--- a/quantecon/_compute_fp.py
+++ b/quantecon/_compute_fp.py
@@ -357,7 +357,7 @@ def _square_sum(a):  # pragma: no cover
     pass
 
 
-@overload(_square_sum, jit_options={'cache':True})
+@overload(_square_sum, jit_options={'cache': True})
 def _square_sum_ol(a):
     if isinstance(a, types.Number):
         return lambda a: a**2

--- a/quantecon/_gridtools.py
+++ b/quantecon/_gridtools.py
@@ -254,7 +254,7 @@ def _cartesian_index(indices, nums_grids):
     n = len(indices)
     idx = 0
     de_cumprod = 1
-    for i in range(1,n+1):
+    for i in range(1, n+1):
         idx += de_cumprod * indices[n-i]
         de_cumprod *= nums_grids[n-i]
     return idx

--- a/quantecon/markov/tests/test_approximation.py
+++ b/quantecon/markov/tests/test_approximation.py
@@ -179,9 +179,9 @@ class TestDiscreteVar:
             [0.00000000e+00, 4.70588235e-01, 3.08823529e-01, 0.00000000e+00, 
             1.76470588e-01, 4.41176471e-02]]
 
-        self.A, self.C, self.S_out, self.P_out, self.S_out_orderF,\
+        self.A, self.C, self.S_out, self.P_out, self.S_out_orderF, \
         self.P_out_orderF, self.P_out_non_square \
-            = map(np.array,(self.A, self.C, self.S_out, self.P_out, 
+            = map(np.array, (self.A, self.C, self.S_out, self.P_out,
                                 self.S_out_orderF, self.P_out_orderF, 
                                 self.P_out_non_square))
 

--- a/quantecon/tests/test_gridtools.py
+++ b/quantecon/tests/test_gridtools.py
@@ -173,7 +173,7 @@ class TestCartesianNearestIndex:
         self.nodes = [list(range(nums[0])), np.linspace(0, 1, nums[1])]
         self.orders = ['C', 'F']
         self.prod_dict = \
-            {order:cartesian(self.nodes, order=order) for order in self.orders}
+            {order: cartesian(self.nodes, order=order) for order in self.orders}
 
     def linear_search(self, x, order='C'):
         x = np.asarray(x)

--- a/quantecon/util/numba.py
+++ b/quantecon/util/numba.py
@@ -21,7 +21,7 @@ def _numba_linalg_solve(a, b):  # pragma: no cover
     pass
 
 
-@overload(_numba_linalg_solve, jit_options={'cache':True})
+@overload(_numba_linalg_solve, jit_options={'cache': True})
 def _numba_linalg_solve_ol(a, b):
     """
     Solve the linear equation ax = b directly calling a Numba internal


### PR DESCRIPTION
## Summary

The flake8 gate in `ci.yml` has never enforced two of the three codes it names. The step is written with spaces after the commas:

```
flake8 --select F401, F405, E231 quantecon
```

The shell splits that into separate arguments, so flake8 receives `--select F401,` (just F401, with a trailing comma) followed by `F405,`, `E231`, and `quantecon` as **positional paths**. The bogus `F405,` / `E231` paths would normally raise file-not-found errors, but those aren't F401 so the `--select` filter drops them — and the step exits 0. Net effect: **only F401 has been enforced; E231 and F405 were silently skipped.**

## Fix

Use the unambiguous form so all three codes are selected against `quantecon`:

```
flake8 --select=F401,F405,E231 quantecon
```

## Pre-existing violations surfaced by turning the gate on

Enabling the gate revealed **6 pre-existing E231 violations** (0 F401, 0 F405) that had been slipping through. Since a gate fix that reddens CI is no fix, those are corrected in the same PR — all are one-character whitespace additions, no behavior change:

| File | Change |
| --- | --- |
| `_compute_fp.py`, `util/numba.py` | `{'cache':True}` → `{'cache': True}` |
| `_gridtools.py` | `range(1,n+1)` → `range(1, n+1)` |
| `tests/test_gridtools.py` | `{order:cartesian(...)}` → `{order: cartesian(...)}` |
| `markov/tests/test_approximation.py` | space after `,` in the unpack continuation and in `map(np.array, (...))` |

Codes outside the selected set (E501, W291, E128, …) remain unenforced exactly as before — this PR does not widen the gate beyond the F401/F405/E231 it was always meant to check.

## Verification

- `flake8 --select=F401,F405,E231 quantecon` — clean (exit 0).
- `pytest` on the affected modules (`test_approximation.py`, `test_gridtools.py`, `test_numba.py`) — 39 passed.

Found while reviewing the CI-hardening work in #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)