### PR TITLE
RLS: setup for v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Future CHANGELOG entries will be documented under the [release notes on GitHub](https://github.com/QuantEcon/QuantEcon.py/releases)
 
+## Ver 0.11.3 (7th-July-2026)
+
+See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.11.3)
+
 ## Ver 0.11.2 (6th-April-2026)
 
 See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.11.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Future CHANGELOG entries will be documented under the [release notes on GitHub](https://github.com/QuantEcon/QuantEcon.py/releases)
 
-## Ver 0.11.3 (7th-July-2026)
+## Ver 0.11.3 (8th-July-2026)
 
 See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.11.3)
 

--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.11.2'
+__version__ = '0.11.3'
 
 try:
     import numba


### PR DESCRIPTION
## Summary

Release setup for **v0.11.3** — bumps `__version__` and adds the CHANGELOG stub, following the standard release pattern.

- `quantecon/__init__.py`: `__version__` `0.11.2` → `0.11.3`
- `CHANGELOG.md`: new `## Ver 0.11.3` entry pointing at the (to-be-created) GitHub release notes

## Merge order

Opened as a **draft** so we are ready to cut the release as soon as the outstanding docs PRs land. Merge this **after**:

- #836 — Add contributing entrypoint
- #850 — Refresh contributing guide and fix stale docs build config

This branch is cut from `main`, so it merges cleanly regardless of when those land — the version bump is independent of their content.

## Before merging

- Confirm **0.11.3** is the intended version (all changes since v0.11.2 are patch-level: bug fixes, CI hardening, refactors, tests, docs).
- Update the CHANGELOG date if the release lands on a day other than the placeholder **7th-July-2026**.
- After merge, tag `v0.11.3` and publish the GitHub release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
