### PR TITLE
BUG: Fix DiscreteDP input validation and iteration edge cases

### DIFF
--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -127,7 +127,7 @@ class DiscreteDP:
 
     There are two ways to represent the data for instantiating a
     `DiscreteDP` object. Let n, m, and L denote the numbers of states,
-    actions, and feasbile state-action pairs, respectively.
+    actions, and feasible state-action pairs, respectively.
 
     1. `DiscreteDP(R, Q, beta)`
 
@@ -297,6 +297,14 @@ class DiscreteDP:
 
     """
     def __init__(self, R, Q, beta, s_indices=None, a_indices=None):
+        if not (0 <= beta <= 1):
+            raise ValueError('beta must be in [0, 1]')
+        if beta == 1:
+            msg = 'infinite horizon solution methods are disabled with beta=1'
+            warnings.warn(msg)
+            self._error_msg_no_discounting = 'method invalid for beta=1'
+        self.beta = beta
+
         self._sa_pair = False
         self._sparse = False
 
@@ -349,9 +357,18 @@ class DiscreteDP:
                 self.a_indptr = a_indptr
             else:
                 # Sort indices and elements of R and Q
+                # (shape supplied explicitly, so that a_indptr has length
+                # num_states+1 even when the last states have no action)
                 sa_ptrs = sp.coo_matrix(
-                    (np.arange(self.num_sa_pairs), (s_indices, a_indices))
+                    (np.arange(self.num_sa_pairs),
+                     (self.s_indices, self.a_indices)),
+                    shape=(self.num_states, self.a_indices.max()+1)
                 ).tocsr()
+                if sa_ptrs.nnz < self.num_sa_pairs:
+                    # Duplicate entries have been summed on the conversion
+                    # to CSR, in which case the pointers would silently
+                    # pick up wrong elements of R and Q
+                    raise ValueError('duplicate state-action pair found')
                 sa_ptrs.sort_indices()
                 self.a_indices = sa_ptrs.indices
                 self.a_indptr = sa_ptrs.indptr
@@ -423,14 +440,6 @@ class DiscreteDP:
         # Check that for every state, at least one action is feasible
         self._check_action_feasibility()
 
-        if not (0 <= beta <= 1):
-            raise ValueError('beta must be in [0, 1]')
-        if beta == 1:
-            msg = 'infinite horizon solution methods are disabled with beta=1'
-            warnings.warn(msg)
-            self._error_msg_no_discounting = 'method invalid for beta=1'
-        self.beta = beta
-
         self.epsilon = 1e-3
         self.max_iter = 250
 
@@ -450,6 +459,20 @@ class DiscreteDP:
         some action available.
 
         """
+        if self._sa_pair:
+            # Check that for every state there is at least one action
+            # available; checked first, since for a state with no action
+            # s_wise_max leaves the corresponding entry of R_max
+            # uninitialized
+            diff = np.diff(self.a_indptr)
+            if (diff == 0).any():
+                # First state index such that no action is available
+                s = np.where(diff == 0)[0][0]
+                raise ValueError(
+                    'for every state at least one action must be available: '
+                    'violated for state {s}'.format(s=s)
+                )
+
         # Check that for every state, reward is finite for some action
         R_max = self.s_wise_max(self.R)
         if (R_max == -np.inf).any():
@@ -459,17 +482,6 @@ class DiscreteDP:
                 'for every state the reward must be finite for some action: '
                 'violated for state {s}'.format(s=s)
             )
-
-        if self._sa_pair:
-            # Check that for every state there is at least one action available
-            diff = np.diff(self.a_indptr)
-            if (diff == 0).any():
-                # First state index such that no action is available
-                s = np.where(diff == 0)[0][0]
-                raise ValueError(
-                    'for every state at least one action must be available: '
-                    'violated for state {s}'.format(s=s)
-                )
 
     def to_sa_pair_form(self, sparse=True):
         """
@@ -484,7 +496,7 @@ class DiscreteDP:
         Returns
         -------
         ddp_sa : DiscreteDP
-            The correspnoding DiscreteDP instance in SA-pair form
+            The corresponding DiscreteDP instance in SA-pair form
 
         Notes
         -----
@@ -513,7 +525,7 @@ class DiscreteDP:
         Returns
         -------
         ddp_sa : DiscreteDP
-            The correspnoding DiscreteDP instance in product form
+            The corresponding DiscreteDP instance in product form
 
         Notes
         -----
@@ -699,7 +711,7 @@ class DiscreteDP:
         """
         # May be replaced with quantecon.compute_fixed_point
         if max_iter <= 0:
-            return v, 0
+            return 0
 
         for i in range(max_iter):
             new_v = T(v, *args, **kwargs)
@@ -719,7 +731,7 @@ class DiscreteDP:
 
         Parameters
         ----------
-        method : str, optinal(default='policy_iteration')
+        method : str, optional(default='policy_iteration')
             Solution method, str in {'value_iteration', 'vi',
             'policy_iteration', 'pi', 'modified_policy_iteration',
             'mpi', 'linear_programming', 'lp'}.
@@ -746,7 +758,7 @@ class DiscreteDP:
         Returns
         -------
         res : DPSolveResult
-            Optimization result represetned as a DPSolveResult. See
+            Optimization result represented as a DPSolveResult. See
             `DPSolveResult` for details.
 
         """
@@ -781,6 +793,8 @@ class DiscreteDP:
 
         if max_iter is None:
             max_iter = self.max_iter
+        if max_iter < 1:
+            raise ValueError('max_iter must be a positive integer')
         if epsilon is None:
             epsilon = self.epsilon
 
@@ -824,6 +838,8 @@ class DiscreteDP:
 
         if max_iter is None:
             max_iter = self.max_iter
+        if max_iter < 1:
+            raise ValueError('max_iter must be a positive integer')
 
         # What for initial condition?
         if v_init is None:
@@ -864,6 +880,8 @@ class DiscreteDP:
 
         if max_iter is None:
             max_iter = self.max_iter
+        if max_iter < 1:
+            raise ValueError('max_iter must be a positive integer')
         if epsilon is None:
             epsilon = self.epsilon
 
@@ -920,6 +938,8 @@ class DiscreteDP:
 
         if max_iter is None:
             max_iter = self.max_iter * self.num_states
+        if max_iter < 1:
+            raise ValueError('max_iter must be a positive integer')
 
         # What for initial condition?
         if v_init is None:

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -350,6 +350,15 @@ class DiscreteDP:
             self.s_indices = np.asarray(s_indices)
             self.a_indices = np.asarray(a_indices)
 
+            # Validate the index ranges here: out-of-range state indices
+            # would otherwise be silently reattributed to other states on
+            # the sorted path below
+            if (self.s_indices < 0).any() or \
+                    (self.s_indices >= self.num_states).any():
+                raise ValueError('s_indices must be in [0, num_states)')
+            if (self.a_indices < 0).any():
+                raise ValueError('a_indices must be nonnegative')
+
             if _has_sorted_sa_indices(self.s_indices, self.a_indices):
                 a_indptr = np.empty(self.num_states+1, dtype=int)
                 _generate_a_indptr(self.num_states, self.s_indices,

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -355,7 +355,9 @@ class DiscreteDP:
             # the sorted path below
             if (self.s_indices < 0).any() or \
                     (self.s_indices >= self.num_states).any():
-                raise ValueError('s_indices must be in [0, num_states)')
+                raise ValueError(
+                    f's_indices must be in [0, {self.num_states})'
+                )
             if (self.a_indices < 0).any():
                 raise ValueError('a_indices must be nonnegative')
 

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -296,6 +296,30 @@ def test_ddp_duplicate_sa_pair_error():
     )
 
 
+def test_ddp_out_of_range_indices_error():
+    # State index 2 out of range for num_states == 2: on the sorted path
+    # the pair would previously be silently reattributed to state 1
+    R = [1.0, 2.0]
+    Q = [(1.0, 0.0), (0.0, 1.0)]
+    Q_sparse = sparse.csr_matrix(Q)
+    beta = 0.95
+
+    # Sorted indices
+    s_indices, a_indices = [0, 2], [0, 0]
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+    assert_raises(
+        ValueError, DiscreteDP, R, Q_sparse, beta, s_indices, a_indices
+    )
+
+    # Unsorted indices
+    s_indices, a_indices = [2, 0], [0, 0]
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+
+    # Negative indices
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, [-1, 0], [0, 0])
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, [0, 1], [0, -1])
+
+
 def test_ddp_nonpositive_max_iter_error():
     n, m = 2, 2
     R = [[0, 1], [1, 0]]
@@ -304,7 +328,9 @@ def test_ddp_nonpositive_max_iter_error():
     ddp = DiscreteDP(R, Q, beta)
 
     for method in ['vi', 'pi', 'mpi', 'lp']:
-        assert_raises(ValueError, ddp.solve, method=method, max_iter=0)
+        for max_iter in [0, -1]:
+            assert_raises(ValueError, ddp.solve, method=method,
+                          max_iter=max_iter)
 
 
 def test_operator_iteration_num_iter():

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -253,7 +253,7 @@ def test_ddp_negative_inf_error():
     )
 
 
-def test_ddp_no_feasibile_action_error():
+def test_ddp_no_feasible_action_error():
     # No action is feasible at state 1
     s_indices = [0, 0, 2, 2]
     a_indices = [0, 1, 0, 1]
@@ -262,6 +262,65 @@ def test_ddp_no_feasibile_action_error():
     beta = 0.95
 
     assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+
+
+def test_ddp_no_feasible_action_error_trailing_state():
+    # No action is feasible at state 2, the last state
+    R = [1, 0, 0, 1]
+    Q = [(1/3, 1/3, 1/3) for i in range(4)]
+    beta = 0.95
+
+    # Sorted indices
+    s_indices = [0, 0, 1, 1]
+    a_indices = [0, 1, 0, 1]
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+
+    # Unsorted indices
+    s_indices = [1, 0, 1, 0]
+    a_indices = [0, 0, 1, 1]
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+
+
+def test_ddp_duplicate_sa_pair_error():
+    # State-action pair (1, 0) is duplicated
+    s_indices = [1, 1, 0, 0]
+    a_indices = [0, 0, 0, 1]
+    R = [1., 2., 3., 4.]
+    Q = [(0.5, 0.5), (1., 0.), (0.25, 0.75), (0.6, 0.4)]
+    Q_sparse = sparse.csr_matrix(Q)
+    beta = 0.95
+
+    assert_raises(ValueError, DiscreteDP, R, Q, beta, s_indices, a_indices)
+    assert_raises(
+        ValueError, DiscreteDP, R, Q_sparse, beta, s_indices, a_indices
+    )
+
+
+def test_ddp_nonpositive_max_iter_error():
+    n, m = 2, 2
+    R = [[0, 1], [1, 0]]
+    Q = np.full((n, m, n), 1/n)
+    beta = 0.95
+    ddp = DiscreteDP(R, Q, beta)
+
+    for method in ['vi', 'pi', 'mpi', 'lp']:
+        assert_raises(ValueError, ddp.solve, method=method, max_iter=0)
+
+
+def test_operator_iteration_num_iter():
+    # The return value must be the number of iterations performed,
+    # in particular 0 (not a tuple) when max_iter <= 0
+    n, m = 2, 2
+    R = [[0, 1], [1, 0]]
+    Q = np.full((n, m, n), 1/n)
+    beta = 0.95
+    ddp = DiscreteDP(R, Q, beta)
+
+    v = np.zeros(n)
+    assert_(ddp.operator_iteration(T=ddp.bellman_operator, v=v,
+                                   max_iter=0) == 0)
+    assert_(ddp.operator_iteration(T=ddp.bellman_operator, v=v,
+                                   max_iter=2) == 2)
 
 
 def test_ddp_beta_1_not_implemented_error():

--- a/quantecon/markov/utilities.py
+++ b/quantecon/markov/utilities.py
@@ -137,10 +137,12 @@ def _generate_a_indptr(num_states, s_indices, out):
         Length must be num_states+1.
 
     """
+    L = len(s_indices)
     idx = 0
     out[0] = 0
     for s in range(num_states-1):
-        while(s_indices[idx] == s):
+        # bound idx: the last states may have no state-action pair
+        while idx < L and s_indices[idx] == s:
             idx += 1
         out[s+1] = idx
-    out[num_states] = len(s_indices)
+    out[num_states] = L


### PR DESCRIPTION
Closes #856.

This PR fixes several input-validation and edge-case bugs in `DiscreteDP` (`quantecon/markov/ddp.py`), found while reviewing the module against its QuantEcon.jl counterpart.

**1. Duplicate state-action pairs silently corrupted the model**

In the state-action pair formulation with unsorted indices, duplicate (s, a) pairs were not detected: `coo_matrix(...).tocsr()` sums duplicate entries, and since the entries here are position pointers into `R` and `Q`, the constructor either raised an uninformative `IndexError` or, when the summed pointer happened to land in bounds, silently built a corrupted instance (`len(R) < num_sa_pairs`, rewards and transition probabilities reassigned across pairs, stale `s_indices`) that then solved without complaint. A `ValueError('duplicate state-action pair found')` is now raised, consistent with the behavior of QuantEcon.jl. Example that previously constructed (and solved) silently:

```python
s_indices = [1, 1, 0, 0]  # (1, 0) duplicated
a_indices = [0, 0, 0, 1]
R = [1., 2., 3., 4.]
Q = [(0.5, 0.5), (1., 0.), (0.25, 0.75), (0.6, 0.4)]
ddp = DiscreteDP(R, Q, 0.95, s_indices, a_indices)  # no error; wrong model
```

**2. Trailing states with no action caused out-of-bounds reads**

With sorted input indices, `_generate_a_indptr` walked `s_indices` past the end whenever the last state(s) had no action available — an unchecked out-of-bounds read under Numba's nopython mode. With unsorted input indices, the `coo_matrix` shape was inferred from the largest indices present, so `a_indptr` came out shorter than `num_states+1`, with the same consequence downstream. The kernel now bounds its walk and the COO shape is passed explicitly, so the intended informative `ValueError` ("for every state at least one action must be available") is raised in both cases. The two checks in `_check_action_feasibility` are also reordered (action availability first), since for a state with no action `s_wise_max` leaves the corresponding entry of `R_max` uninitialized.

**3. `operator_iteration` returned a tuple when `max_iter <= 0`, and `max_iter=0` crashed `policy_iteration`**

`operator_iteration` returned `(v, 0)` instead of the documented `num_iter` on its early-return path. The four solution methods now raise `ValueError` for `max_iter < 1` (previously `policy_iteration` died with `NameError`, and `value_iteration` stored the tuple in `res.num_iter`).

**4. Cosmetics**

`beta` is now validated at the top of `__init__` (previously only after the index-sorting work); typo fixes in docstrings ("optinal", "represetned", "correspnoding", "feasbile") and in a test name.

Tests are added for each fix; the full `quantecon/markov` test suite passes (90 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
