### PR TITLE
PERF: Compute dense Q @ v with a single gemv in bellman_operator

### DIFF
--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -427,6 +427,17 @@ class DiscreteDP:
             self.s_indices, self.a_indices = None, None
             self.num_sa_pairs = (self.R > -np.inf).sum()
 
+            # 2-dimensional view of Q, of shape (n*m, n), so that Q @ v in
+            # bellman_operator is computed with a single gemv call instead
+            # of a batched matmul over n stacked matrices (a view is only
+            # possible when Q is C-contiguous; otherwise fall back)
+            if self.Q.flags.c_contiguous:
+                self._Q_2d = self.Q.reshape(n*m, n)
+            else:
+                self._Q_2d = None
+
+            self._s_arange = np.arange(n)  # cached for indexing by state
+
             # Define state-wise maximization
             def s_wise_max(vals, out=None, out_argmax=None):
                 """
@@ -443,7 +454,7 @@ class DiscreteDP:
                     vals.max(axis=1, out=out)
                 else:
                     vals.argmax(axis=1, out=out_argmax)
-                    out[:] = vals[np.arange(self.num_states), out_argmax]
+                    out[:] = vals[self._s_arange, out_argmax]
                 return out
 
             self.s_wise_max = s_wise_max
@@ -585,8 +596,8 @@ class DiscreteDP:
                           out=sigma_indices)
             R_sigma, Q_sigma = self.R[sigma_indices], self.Q[sigma_indices]
         else:
-            R_sigma = self.R[np.arange(self.num_states), sigma]
-            Q_sigma = self.Q[np.arange(self.num_states), sigma]
+            R_sigma = self.R[self._s_arange, sigma]
+            Q_sigma = self.Q[self._s_arange, sigma]
 
         return R_sigma, Q_sigma
 
@@ -613,7 +624,13 @@ class DiscreteDP:
             Updated value function vector, of length n.
 
         """
-        vals = self.R + self.beta * (self.Q @ v)  # Shape: (L,) or (n, m)
+        if self._sa_pair or self._Q_2d is None:
+            Qv = self.Q @ v
+        else:
+            # a single gemv over the 2-d view of Q, instead of a batched
+            # matmul over n stacked (m, n) matrices
+            Qv = (self._Q_2d @ v).reshape(self.R.shape)
+        vals = self.R + self.beta * Qv  # Shape: (L,) or (n, m)
 
         if Tv is None:
             Tv = np.empty(self.num_states)

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -427,15 +427,6 @@ class DiscreteDP:
             self.s_indices, self.a_indices = None, None
             self.num_sa_pairs = (self.R > -np.inf).sum()
 
-            # 2-dimensional view of Q, of shape (n*m, n), so that Q @ v in
-            # bellman_operator is computed with a single gemv call instead
-            # of a batched matmul over n stacked matrices (a view is only
-            # possible when Q is C-contiguous; otherwise fall back)
-            if self.Q.flags.c_contiguous:
-                self._Q_2d = self.Q.reshape(n*m, n)
-            else:
-                self._Q_2d = None
-
             self._s_arange = np.arange(n)  # cached for indexing by state
 
             # Define state-wise maximization
@@ -624,12 +615,15 @@ class DiscreteDP:
             Updated value function vector, of length n.
 
         """
-        if self._sa_pair or self._Q_2d is None:
-            Qv = self.Q @ v
+        if not self._sa_pair and self.Q.flags.c_contiguous:
+            # a single gemv over a 2-d view of Q (a view, since Q is
+            # C-contiguous), instead of a batched matmul over n stacked
+            # (m, n) matrices; the view is taken per call, so that a
+            # rebound self.Q is picked up
+            n, m = self.R.shape
+            Qv = (self.Q.reshape(n*m, n) @ v).reshape(n, m)
         else:
-            # a single gemv over the 2-d view of Q, instead of a batched
-            # matmul over n stacked (m, n) matrices
-            Qv = (self._Q_2d @ v).reshape(self.R.shape)
+            Qv = self.Q @ v
         vals = self.R + self.beta * Qv  # Shape: (L,) or (n, m)
 
         if Tv is None:

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -351,23 +351,48 @@ def test_operator_iteration_num_iter():
 
 def test_ddp_non_c_contiguous_Q():
     # A non-C-contiguous Q must fall back to the batched-matmul path in
-    # bellman_operator and give the same results
-    n, m = 3, 2
-    R = np.array([[0., 1.], [1., 0.], [0., 1.]])
-    Q = np.empty((n, m, n))
-    Q[:] = 1/n
+    # bellman_operator and give the same results as the gemv path
+    n, m = 20, 5
+    rs = np.random.RandomState(12345)
+    R = rs.random_sample((n, m))
+    Q = rs.random_sample((n, m, n))
+    Q /= Q.sum(axis=2, keepdims=True)
     beta = 0.95
 
     ddp_c = DiscreteDP(R, Q, beta)
     ddp_f = DiscreteDP(R, np.asfortranarray(Q), beta)
-    assert_(ddp_c._Q_2d is not None)
-    assert_(ddp_f._Q_2d is None)
+    assert_(ddp_c.Q.flags.c_contiguous)
+    assert_(not ddp_f.Q.flags.c_contiguous)
+
+    # Direct comparison of the Bellman operator and the greedy policy
+    v = rs.random_sample(n)
+    sigma_c = np.empty(n, dtype=int)
+    sigma_f = np.empty(n, dtype=int)
+    Tv_c = ddp_c.bellman_operator(v, sigma=sigma_c)
+    Tv_f = ddp_f.bellman_operator(v, sigma=sigma_f)
+    assert_allclose(Tv_f, Tv_c)
+    assert_array_equal(sigma_f, sigma_c)
 
     for method in ['vi', 'pi', 'mpi']:
         res_c = ddp_c.solve(method=method)
         res_f = ddp_f.solve(method=method)
         assert_array_equal(res_f.sigma, res_c.sigma)
         assert_allclose(res_f.v, res_c.v)
+
+
+def test_ddp_Q_rebinding():
+    # bellman_operator must reflect a rebound ddp.Q (no stale cache)
+    n, m = 3, 2
+    R = np.arange(n*m, dtype=float).reshape(n, m)
+    Q1 = np.tile([[0.2, 0.3, 0.5], [0.6, 0.3, 0.1]], (n, 1, 1))
+    Q2 = np.tile([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], (n, 1, 1))
+    beta = 0.9
+    v = np.array([1., 2., 3.])
+
+    ddp = DiscreteDP(R, Q1, beta)
+    ddp.Q = Q2
+    assert_allclose(ddp.bellman_operator(v),
+                    DiscreteDP(R, Q2, beta).bellman_operator(v))
 
 
 def test_ddp_beta_1_not_implemented_error():

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -349,6 +349,27 @@ def test_operator_iteration_num_iter():
                                    max_iter=2) == 2)
 
 
+def test_ddp_non_c_contiguous_Q():
+    # A non-C-contiguous Q must fall back to the batched-matmul path in
+    # bellman_operator and give the same results
+    n, m = 3, 2
+    R = np.array([[0., 1.], [1., 0.], [0., 1.]])
+    Q = np.empty((n, m, n))
+    Q[:] = 1/n
+    beta = 0.95
+
+    ddp_c = DiscreteDP(R, Q, beta)
+    ddp_f = DiscreteDP(R, np.asfortranarray(Q), beta)
+    assert_(ddp_c._Q_2d is not None)
+    assert_(ddp_f._Q_2d is None)
+
+    for method in ['vi', 'pi', 'mpi']:
+        res_c = ddp_c.solve(method=method)
+        res_f = ddp_f.solve(method=method)
+        assert_array_equal(res_f.sigma, res_c.sigma)
+        assert_allclose(res_f.v, res_c.v)
+
+
 def test_ddp_beta_1_not_implemented_error():
     n, m = 3, 2
     R = np.array([[0, 1], [1, 0], [0, 1]])


### PR DESCRIPTION
This PR is the Python side of the DDP performance pass (the Julia side is QuantEcon/QuantEcon.jl#386, merged). It contains no behavioral changes — all solutions are bit-identical.

Note: rebased on main after the merge of #855; the diff is now the PERF commit plus the review-fix commit (per-call view instead of a cached one).

**Change**

For the product formulation, `Q @ v` with the 3-dimensional `Q` is a batched matmul: n separate `(m, n) @ (n,)` products, with per-slice dispatch overhead. Since `Q` is C-contiguous in the standard case, the same computation is a single gemv over a 2-dimensional `(n*m, n)` view. `bellman_operator` now takes that 2-D view per call when `Q` is C-contiguous (a view is free, and taking it per call means a rebound `ddp.Q` is picked up — no cached state); a non-C-contiguous `Q` (where the reshape would silently copy) falls back to the previous path, with regression tests covering both paths and `Q` rebinding. The `np.arange(num_states)` used for indexing by state in `RQ_sigma` and `s_wise_max` is also cached instead of allocated per call.

This also removes a historical asymmetry between the two dense representations: the state-action-pair form has always computed `Q @ v` as a single gemv, which is why it used to outperform the product form by ~1.5-2x on identical data (visible e.g. in the 2015 benchmark notebook [oyamad/mdp/ddp_performance.ipynb](https://github.com/oyamad/mdp/blob/master/ddp_performance.ipynb)); with this change the two dense forms are performance-equivalent.

**Measured effect** (identical random models across runs; values and iteration counts unchanged):

| | before | after | speedup |
|:---|---:|---:|---:|
| `bellman_operator`, n=500, m=100 | 2.79 ms | 1.03 ms | **2.7x** |
| `solve('vi')`, n=500, m=100 (206 iter) | 601 ms | 405 ms | **1.5x** |
| `bellman_operator`, n=100, m=50 | 66 us | 22 us | **3.0x** |
| `solve('vi')`, n=100, m=50 | 14.0 ms | 7.6 ms | **1.8x** |

PFI/MPFI improve slightly (14.1 → 11.8 ms and ~unchanged at n=500); the state-action-pair formulation is unaffected.

**Considered and rejected, for the record**

- A fused Numba max+argmax kernel to replace the two-pass `argmax` + fancy-index gather in the dense `s_wise_max`: measured *slower* than NumPy (105 us vs 60 us at n=3000, m=50) — NumPy's SIMD-vectorized `argmax` beats the branchy scalar loop. Kept the current implementation.
- SuperLU tuning for the sparse `evaluate_policy` (`permc_spec` variants): at most 1.4x on a random-pattern test case — not worth the complexity.

**A finding worth separate discussion** (not included here since it changes solver semantics): for the sparse formulation, `evaluate_policy`'s direct `spsolve` suffers badly from LU fill-in on scattered sparsity patterns, while Krylov methods exploit the structure of `A = I - beta Q_sigma` — strictly diagonally dominant, condition number bounded by `(1+beta)/(1-beta)` — extremely well. On a random-pattern case with n=3000 and 5 nonzeros per row: `spsolve` 522 ms vs `bicgstab(rtol=1e-12)` **0.8 ms**, accurate to ~1e-12. Since an iterative solve makes policy evaluation tolerance-based rather than direct (which touches policy iteration's exactness property), I'd propose it as an opt-in (e.g. a solver option) in a separate issue rather than a silent default change. Happy to open that issue if there is interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
