### PR TITLE
MAINT: Make s_wise_max an ordinary method; DiscreteDP now picklable

### DIFF
--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -394,27 +394,6 @@ class DiscreteDP:
                         _s_indices[j] = i
                 self.s_indices = _s_indices
 
-            # Define state-wise maximization
-            def s_wise_max(vals, out=None, out_argmax=None):
-                """
-                Return the vector max_a vals(s, a), where vals is represented
-                by a 1-dimensional ndarray of shape (self.num_sa_pairs,).
-                out and out_argmax must be of length self.num_states; dtype of
-                out_argmax must be int.
-
-                """
-                if out is None:
-                    out = np.empty(self.num_states)
-                if out_argmax is None:
-                    _s_wise_max(self.a_indices, self.a_indptr, vals,
-                                out_max=out)
-                else:
-                    _s_wise_max_argmax(self.a_indices, self.a_indptr, vals,
-                                       out_max=out, out_argmax=out_argmax)
-                return out
-
-            self.s_wise_max = s_wise_max
-
         else:  # Not self._sa_pair
             if self.R.ndim != 2:
                 raise ValueError(msg_dimension)
@@ -428,27 +407,6 @@ class DiscreteDP:
             self.num_sa_pairs = (self.R > -np.inf).sum()
 
             self._s_arange = np.arange(n)  # cached for indexing by state
-
-            # Define state-wise maximization
-            def s_wise_max(vals, out=None, out_argmax=None):
-                """
-                Return the vector max_a vals(s, a), where vals is represented
-                by a 2-dimensional ndarray of shape (n, m). Stored in out,
-                which must be of length self.num_states.
-                out and out_argmax must be of length self.num_states; dtype of
-                out_argmax must be int.
-
-                """
-                if out is None:
-                    out = np.empty(self.num_states)
-                if out_argmax is None:
-                    vals.max(axis=1, out=out)
-                else:
-                    vals.argmax(axis=1, out=out_argmax)
-                    out[:] = vals[self._s_arange, out_argmax]
-                return out
-
-            self.s_wise_max = s_wise_max
 
         # Check that for every state, at least one action is feasible
         self._check_action_feasibility()
@@ -495,6 +453,36 @@ class DiscreteDP:
                 'for every state the reward must be finite for some action: '
                 'violated for state {s}'.format(s=s)
             )
+
+    def s_wise_max(self, vals, out=None, out_argmax=None):
+        """
+        Return the vector max_a vals(s, a), where vals is represented by
+        a 1-dimensional ndarray of shape (self.num_sa_pairs,) for the
+        state-action pair formulation, and by a 2-dimensional ndarray of
+        shape (n, m) for the product formulation. Stored in out, which
+        must be of length self.num_states; dtype of out_argmax must be
+        int.
+
+        Note: an ordinary method (not a closure set in __init__), so
+        that DiscreteDP instances are picklable.
+
+        """
+        if out is None:
+            out = np.empty(self.num_states)
+        if self._sa_pair:
+            if out_argmax is None:
+                _s_wise_max(self.a_indices, self.a_indptr, vals,
+                            out_max=out)
+            else:
+                _s_wise_max_argmax(self.a_indices, self.a_indptr, vals,
+                                   out_max=out, out_argmax=out_argmax)
+        else:
+            if out_argmax is None:
+                vals.max(axis=1, out=out)
+            else:
+                vals.argmax(axis=1, out=out_argmax)
+                out[:] = vals[self._s_arange, out_argmax]
+        return out
 
     def to_sa_pair_form(self, sparse=True):
         """

--- a/quantecon/markov/ddp.py
+++ b/quantecon/markov/ddp.py
@@ -463,9 +463,6 @@ class DiscreteDP:
         must be of length self.num_states; dtype of out_argmax must be
         int.
 
-        Note: an ordinary method (not a closure set in __init__), so
-        that DiscreteDP instances are picklable.
-
         """
         if out is None:
             out = np.empty(self.num_states)

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -2,6 +2,8 @@
 Tests for markov/ddp.py
 
 """
+import pickle
+
 import numpy as np
 import scipy.sparse as sparse
 from numpy.testing import (assert_array_equal, assert_allclose, assert_raises,
@@ -393,6 +395,28 @@ def test_ddp_Q_rebinding():
     ddp.Q = Q2
     assert_allclose(ddp.bellman_operator(v),
                     DiscreteDP(R, Q2, beta).bellman_operator(v))
+
+
+def test_ddp_picklable():
+    # DiscreteDP instances must be picklable (e.g. for multiprocessing);
+    # s_wise_max used to be a closure set in __init__, which broke this
+    n, m = 2, 2
+    R = [[5, 10], [-1, -np.inf]]
+    Q = np.empty((n, m, n))
+    Q[0, 0, :] = 0.5, 0.5
+    Q[0, 1, :] = 0, 1
+    Q[1, :, :] = 0, 1
+    beta = 0.95
+
+    ddp0 = DiscreteDP(R, Q, beta)
+    ddps = [ddp0, ddp0.to_sa_pair_form(), ddp0.to_sa_pair_form(sparse=False)]
+
+    for ddp in ddps:
+        ddp2 = pickle.loads(pickle.dumps(ddp))
+        res = ddp.solve(method='pi')
+        res2 = ddp2.solve(method='pi')
+        assert_allclose(res2.v, res.v)
+        assert_array_equal(res2.sigma, res.sigma)
 
 
 def test_ddp_beta_1_not_implemented_error():


### PR DESCRIPTION
`DiscreteDP.__init__` defined `s_wise_max` as a local closure and assigned it as an instance attribute (one variant per formulation). Local functions cannot be pickled, so `DiscreteDP` instances failed with `AttributeError: Can't get local object 'DiscreteDP.__init__.<locals>.s_wise_max'` under `pickle` — blocking `multiprocessing` and caching workflows.

This PR replaces the two closures with a single ordinary method dispatching on `self._sa_pair`. Call syntax and behavior are unchanged (`ddp.s_wise_max(vals, out=..., out_argmax=...)`), and the remaining instance state (`_lineq_solve` holding module-level functions, sparse `_I`) is picklable, so instances now round-trip. A pickle round-trip test over the three representations (product, sa-sparse, sa-dense) is added.

This is the Python half of the last item of the cross-implementation feature-sync plan (see QuantEcon/QuantEcon.jl#389 for the Julia half of the converters/metadata side); it follows up on #855/#857, on top of which it was developed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
