### PR TITLE
PERF: Vectorize the update loop in _pivoting

### DIFF
--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -35,9 +35,15 @@ def _pivoting(tableau, pivot_col, pivot_row):
     """
     nrows, ncols = tableau.shape
 
-    pivot_elt = tableau[pivot_row, pivot_col]
+    r = 1 / tableau[pivot_row, pivot_col]
+    # Copy of the normalized pivot row: reading it from `tableau` inside
+    # the update loop would create a potential-aliasing hazard with the
+    # row being updated, preventing the loop from being vectorized
+    pivot_row_buf = np.empty(ncols, dtype=tableau.dtype)
     for j in range(ncols):
-        tableau[pivot_row, j] /= pivot_elt
+        v = tableau[pivot_row, j] * r
+        pivot_row_buf[j] = v
+        tableau[pivot_row, j] = v
 
     for i in range(nrows):
         if i == pivot_row:
@@ -46,7 +52,12 @@ def _pivoting(tableau, pivot_col, pivot_row):
         if multiplier == 0:
             continue
         for j in range(ncols):
-            tableau[i, j] -= tableau[pivot_row, j] * multiplier
+            tableau[i, j] -= pivot_row_buf[j] * multiplier
+
+    # Eliminate possible floating-point residue
+    for i in range(nrows):
+        tableau[i, pivot_col] = 0
+    tableau[pivot_row, pivot_col] = 1
 
     return tableau
 

--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -35,13 +35,15 @@ def _pivoting(tableau, pivot_col, pivot_row):
     """
     nrows, ncols = tableau.shape
 
-    r = 1 / tableau[pivot_row, pivot_col]
+    pivot_elt = tableau[pivot_row, pivot_col]
     # Copy of the normalized pivot row: reading it from `tableau` inside
     # the update loop would create a potential-aliasing hazard with the
-    # row being updated, preventing the loop from being vectorized
+    # row being updated, preventing the loop from being vectorized.
+    # Normalized by direct division, not reciprocal multiplication, which
+    # can overflow (e.g. for subnormal pivots) where division stays finite
     pivot_row_buf = np.empty(ncols, dtype=tableau.dtype)
     for j in range(ncols):
-        v = tableau[pivot_row, j] * r
+        v = tableau[pivot_row, j] / pivot_elt
         pivot_row_buf[j] = v
         tableau[pivot_row, j] = v
 

--- a/quantecon/optimize/tests/test_pivoting.py
+++ b/quantecon/optimize/tests/test_pivoting.py
@@ -1,0 +1,50 @@
+"""
+Tests for pivoting.py
+
+"""
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from quantecon.optimize.pivoting import _pivoting
+
+
+def _pivoting_reference(tableau, pivot_col, pivot_row):
+    # Direct-division reference implementation
+    tableau = tableau.copy()
+    tableau[pivot_row, :] /= tableau[pivot_row, pivot_col]
+    for i in range(tableau.shape[0]):
+        if i != pivot_row:
+            tableau[i, :] -= tableau[pivot_row, :] * tableau[i, pivot_col]
+    tableau[:, pivot_col] = 0
+    tableau[pivot_row, pivot_col] = 1
+    return tableau
+
+
+class TestPivoting:
+    def test_equals_direct_division_reference(self):
+        rng = np.random.default_rng(0)
+        nrows, ncols = 10, 22
+        pivot_col, pivot_row = 2, 1
+        tableau_0 = rng.random((nrows, ncols)) + 0.5
+        desired = _pivoting_reference(tableau_0, pivot_col, pivot_row)
+        tableau = tableau_0.copy()
+        _pivoting(tableau, pivot_col, pivot_row)
+        assert_array_equal(tableau, desired)
+
+    def test_pivot_column_exact_unit_vector(self):
+        rng = np.random.default_rng(1)
+        nrows, ncols = 6, 14
+        pivot_col, pivot_row = 3, 4
+        tableau = rng.random((nrows, ncols)) + 0.5
+        _pivoting(tableau, pivot_col, pivot_row)
+        e = np.zeros(nrows)
+        e[pivot_row] = 1
+        assert_array_equal(tableau[:, pivot_col], e)
+
+    def test_subnormal_pivot_stays_finite(self):
+        # 1/p overflows for a subnormal pivot, while direct division
+        # stays finite
+        p = np.float64(1e-309)
+        tableau = np.array([[p, p, 0.], [p, 2*p, p]])
+        _pivoting(tableau, 0, 0)
+        assert_array_equal(tableau, np.array([[1., 1., 0.], [0., p, p]]))


### PR DESCRIPTION
This PR speeds up `_pivoting` in `quantecon/optimize/pivoting.py`, the kernel shared by `lcp_lemke`, `linprog_simplex`, `howson_lcp`, `_ddp_linprog_simplex`, and `lemke_howson`. The function signature, `cache=True`, and all call sites are unchanged, so every caller inherits the speedup.

## Changes

- The normalized pivot row is copied into a buffer before the update loop. Reading it from `tableau` inside the loop creates a potential-aliasing hazard with the row being updated (the compiler cannot prove row `i` and the pivot row do not overlap), which prevented the loop from being vectorized; the buffer breaks the hazard. This is the entire source of the speedup.
- The pivot row normalization still divides directly — a reciprocal-multiplication variant was reverted in review (by ChatGPT): it overflows for subnormal pivots where division stays finite, and `_pivoting` itself imposes no lower bound on the pivot element; the buffered division measures identically. An explicit cleanup pass reduces the pivot column to the exact unit vector, matching the Julia kernels in QuantEcon.jl (see QuantEcon/QuantEcon.jl#397, the counterpart of this PR).
- The zero-multiplier row skip is retained; it is a per-row branch outside the inner loop and does not inhibit vectorization.

The kernel's output is numerically identical to the previous implementation — the same divisions and updates on the same values; the only possible bit-level difference is that the cleanup pass canonicalizes signed zeros in the pivot column to +0.0. A focused `test_pivoting.py` is added (direct-division reference comparison, exact-unit-pivot-column invariant, subnormal-pivot regression); all tests of the downstream modules pass (`test_lcp_lemke`, `test_linprog_simplex`, `test_howson_lcp`, `test_lemke_howson`, `test_ddp`).

## Benchmarks

Per pivot on an `n x (2n+2)` tableau (minimum times):

| n | before | after | speedup |
|--:|--:|--:|--:|
| 10 | 0.21 μs | 0.21 μs | 1.0x |
| 50 | 1.50 μs | 0.79 μs | 1.9x |
| 200 | 19.5 μs | 10.8 μs | 1.8x |
| 1000 | 463 μs | 270 μs | 1.7x |

`lemke_howson` end to end on random `n x n` games (200 games per size, median):

| n | before | after | speedup |
|--:|--:|--:|--:|
| 10 | 4.2 μs | 4.7 μs | 0.9x |
| 30 | 22.3 μs | 16.0 μs | 1.4x |
| 50 | 100.1 μs | 52.2 μs | 1.9x |
| 100 | 2358 μs | 1240 μs | 1.9x |

Very small games (n = 2, 3, 5, 10): 2.9 / 3.2 / 3.4 / 4.5 μs median, dominated by the numba call boundary; the n=10 difference from the pre-PR 4.2 μs is within run-to-run noise (the kernel itself times identically, 0.21–0.25 μs across process launches for both versions), so no small-size cutoff is warranted.

A note for anyone benchmarking this locally: numba's on-disk cache does not track cross-module dependencies, so cached compilations of the *callers* keep inlining the old `_pivoting` until their caches are cleared. Fresh environments are unaffected; an in-place upgrade that leaves old caches behind would at worst miss the speedup, not change results, since the kernel's output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
