### PR TITLE
RLS: setup for v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Future CHANGELOG entries will be documented under the [release notes on GitHub](https://github.com/QuantEcon/QuantEcon.py/releases)
 
+## Ver 0.11.4 (14th-July-2026)
+
+See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.11.4)
+
 ## Ver 0.11.3 (8th-July-2026)
 
 See [release notes](https://github.com/QuantEcon/QuantEcon.py/releases/tag/v0.11.3)

--- a/quantecon/__init__.py
+++ b/quantecon/__init__.py
@@ -3,7 +3,7 @@
 Import the main names to top level.
 """
 
-__version__ = '0.11.3'
+__version__ = '0.11.4'
 
 try:
     import numba


### PR DESCRIPTION
Prepares the **v0.11.4** patch release: bumps `__version__` to `0.11.4` and adds a `CHANGELOG.md` stub. After merge, push the `v0.11.4` tag to trigger the `flit publish` job to PyPI.

## Changes since v0.11.3

| PR | Type | Summary |
|--|--|--|
| #860 | FIX | markov: fix invalid states in `simulate` (deficient row sums, #591), sparse negative init out-of-bounds, and `__str__` returning the bound-method wrapper |
| #861 | PERF | vectorize the update loop in `_pivoting` (~1.7–1.9x on larger tableaux; all downstream kernels inherit it) |
| #859 | MAINT | make `s_wise_max` an ordinary method so `DiscreteDP` instances are picklable (multiprocessing/caching) |

## Release note to highlight

`mc_sample_path` now **validates** a user-supplied initial distribution and raises `ValueError` on non-1-d / wrong-length / negative / non-normalized input (previously silently accepted) — a minor API tightening from #860. Also from #860: `simulate_indices(init=-k)` now returns `n-k` in the first position rather than `-k` (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)