### PR TITLE
DOC: Refresh contributor-facing metadata

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,9 +20,8 @@ Always reference these instructions first and fallback to search or bash command
   - Takes < 30 seconds
   - Note: Repository has some existing style violations - this is expected
 - **Full test suite**: `coverage run -m pytest quantecon`
-  - Takes 5 minutes 11 seconds. NEVER CANCEL. Set timeout to 15+ minutes.
-  - Runs 536 tests across all modules
-  - All tests should pass with 2 warnings (expected)
+  - Runs 600+ tests and takes several minutes. NEVER CANCEL. Set timeout to 15+ minutes.
+  - All tests should pass; investigate any unexpected warnings.
 - **Quick smoke test**: `python -c "import quantecon as qe; print('Version:', qe.__version__)"`
 - **Package build**: `flit build`
   - Creates wheel and source distributions in dist/
@@ -54,7 +53,7 @@ print('DiscreteDP test successful, policy:', result.sigma)
   - `game_theory/` - Game theory algorithms and utilities  
   - `optimize/` - Optimization algorithms
   - `random/` - Random number generation utilities
-  - `tests/` - Main test suite (536 tests total)
+  - `tests/` - Main test suite (600+ tests total)
 
 ### Configuration Files
 - `pyproject.toml` - Main project configuration using flit build system
@@ -74,7 +73,7 @@ Core runtime dependencies (auto-installed in conda env):
 
 **CRITICAL TIMING INFORMATION:**
 - **Conda environment creation**: 3-5 minutes (timeout: 10+ minutes)
-- **Full test suite**: 5 minutes 11 seconds (timeout: 15+ minutes) 
+- **Full test suite**: several minutes (timeout: 15+ minutes)
 - **Package build**: < 30 seconds (timeout: 2 minutes)
 - **Development install**: < 30 seconds (timeout: 2 minutes)
 - **Linting**: < 30 seconds (timeout: 2 minutes)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,6 @@
 cff-version: "1.2.0"
+version: "0.11.4"
+date-released: 2026-07-15
 authors:
 - family-names: Batista
   given-names: Quentin

--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ A high performance, open source Python code library for economics
 
 ## Installation
 
-Before installing `quantecon` we recommend you install the [Anaconda](https://www.anaconda.com/download/) Python distribution, which includes a full suite of scientific python tools.
-
-Next you can install quantecon by opening a terminal prompt and typing
+Install `quantecon` from PyPI by opening a terminal and typing
 
     pip install quantecon
 
-or using conda-forge by typing
+Alternatively, install the conda-forge package by typing
 
     conda install -c conda-forge quantecon
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -80,6 +80,15 @@ The rendered pages are written to ``docs/build/html``. Once you open a pull requ
 documentation is also built automatically by `Read the Docs <https://readthedocs.org>`_ and linked from
 the pull request checks.
 
+Prepare a release
+-----------------
+
+Before tagging a release:
+
+* Update ``__version__`` in ``quantecon/__init__.py``.
+* Update ``version`` and ``date-released`` in ``CITATION.cff`` to match the release.
+* Run ``cffconvert --validate`` to validate the citation metadata.
+
 Further questions
 -----------------
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -1,16 +1,13 @@
 Installation
 ============
 
-Before installing `quantecon` we recommend you install the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution, 
-which includes a full suite of scientific python tools.
-
-Next you can install quantecon by opening a terminal prompt and typing
+Install ``quantecon`` from PyPI by opening a terminal and typing
 
 .. code:: bash
 
     pip install quantecon
 
-and using `conda-forge` by typing
+Alternatively, install the ``conda-forge`` package by typing
 
 .. code:: bash
 


### PR DESCRIPTION
## Summary

- make the README and rendered setup guide pip-first while retaining the conda-forge path
- add the current software version and release date to `CITATION.cff`, preserving the JOSS article publication date
- replace brittle test counts and timings with durable guidance
- add a release checklist so citation metadata stays current

## Validation

- `cffconvert --validate`
- `flake8 --select=F401,F405,E231 quantecon`
- `pytest quantecon` (600 passed, 2 existing warnings)
- Sphinx HTML documentation build

Closes #900