### PR TITLE
FIX: assert the sparse-Q equality check in test_ddp.py

### DIFF
--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -465,8 +465,8 @@ def test_ddp_to_sa_and_to_product():
     # make sure conversion worked
     for ddp_s in [ddp_sa, ddp_sa2, ddp_sa3]:
         assert_allclose(ddp_s.R, sparse_R)
-        # allcose doesn't work on sparse
-        np.max(np.abs((sparse_Q - ddp_s.Q))) < 1e-15
+        # allclose doesn't work on sparse
+        assert np.max(np.abs((sparse_Q - ddp_s.Q))) < 1e-15
         assert_allclose(ddp_s.beta, beta)
 
     # these two will have probability 0 in state 2, action 0 b/c

--- a/quantecon/markov/tests/test_ddp.py
+++ b/quantecon/markov/tests/test_ddp.py
@@ -466,7 +466,7 @@ def test_ddp_to_sa_and_to_product():
     for ddp_s in [ddp_sa, ddp_sa2, ddp_sa3]:
         assert_allclose(ddp_s.R, sparse_R)
         # allclose doesn't work on sparse
-        assert np.max(np.abs((sparse_Q - ddp_s.Q))) < 1e-15
+        assert_(np.max(np.abs((sparse_Q - ddp_s.Q))) < 1e-15)
         assert_allclose(ddp_s.beta, beta)
 
     # these two will have probability 0 in state 2, action 0 b/c


### PR DESCRIPTION
Closes #874

The sparse-Q comparison in `test_ddp_to_sa_and_to_product` computed a boolean and threw it away, so that check has never verified anything — a wrong converted `Q` would pass silently. This adds the missing `assert` (and fixes the adjacent `allcose` typo).

The assertion passes against the current conversion code; substituting a deliberately wrong `Q` into the same expression raises `AssertionError`, confirming it now guards. `pytest quantecon/markov/tests/test_ddp.py` is green (20 passed).
