### PR TITLE
MAINT: Replace deprecated ndarray shape assignments

### DIFF
--- a/quantecon/_kalman.py
+++ b/quantecon/_kalman.py
@@ -75,7 +75,7 @@ class Kalman:
             self.x_hat = np.zeros((self.ss.n, 1))
         else:
             self.x_hat = np.atleast_2d(x_hat)
-            self.x_hat.shape = self.ss.n, 1
+            self.x_hat = self.x_hat.reshape(self.ss.n, 1)
 
     def __repr__(self):
         return self.__str__()
@@ -204,7 +204,7 @@ class Kalman:
 
         # === and then update === #
         y = np.atleast_2d(y)
-        y.shape = self.ss.k, 1
+        y = y.reshape(self.ss.k, 1)
         E = self.Sigma @ G.T
         F = (G @ self.Sigma @ G.T) + R
         M = E @ inv(F)

--- a/quantecon/_lss.py
+++ b/quantecon/_lss.py
@@ -126,7 +126,7 @@ class LinearStateSpace:
             self.mu_0 = np.zeros((self.n, 1))
         else:
             self.mu_0 = self.convert(mu_0)
-            self.mu_0.shape = self.n, 1
+            self.mu_0 = self.mu_0.reshape(self.n, 1)
         if Sigma_0 is None:
             self.Sigma_0 = np.zeros((self.n, self.n))
         else:

--- a/quantecon/game_theory/game_generators/tests/test_bimatrix_generators.py
+++ b/quantecon/game_theory/game_generators/tests/test_bimatrix_generators.py
@@ -80,7 +80,7 @@ def test_sgc_game():
         0.500 0.000 0.500 0.000 0.500 0.000 0.000 0.000 0.000 0.000 0.000 0.750
         0.750 0.000"""
     bimatrix = np.fromstring(s, sep=' ')
-    bimatrix.shape = (4*k-1, 4*k-1, 2)
+    bimatrix = bimatrix.reshape(4*k-1, 4*k-1, 2)
     bimatrix = bimatrix.swapaxes(0, 1)
 
     g = sgc_game(k)

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -461,7 +461,7 @@ class Player:
         if D.shape[0] == 0:  # num_actions == 1
             return False
         if self.num_opponents >= 2:
-            D.shape = (D.shape[0], np.prod(D.shape[1:]))
+            D = D.reshape(D.shape[0], np.prod(D.shape[1:]))
 
         if method is None:
             from ..optimize.minmax import minmax

--- a/quantecon/markov/random.py
+++ b/quantecon/markov/random.py
@@ -206,8 +206,8 @@ def random_discrete_dp(num_states, num_actions, beta=None,
         s_indices, a_indices = sa_indices(num_states, num_actions)
     else:
         s_indices, a_indices = None, None
-        R.shape = (num_states, num_actions)
-        Q.shape = (num_states, num_actions, num_states)
+        R = R.reshape(num_states, num_actions)
+        Q = Q.reshape(num_states, num_actions, num_states)
 
     ddp = DiscreteDP(R, Q, beta, s_indices, a_indices)
     return ddp


### PR DESCRIPTION
## Summary

Replace in-place NumPy `ndarray.shape` assignments covered by #909 with `reshape(...)` calls, avoiding the NumPy 2.5 deprecation while preserving the target shapes.

## Changes

- Update the five affected implementation/test files identified in the issue.
- Preserve existing dimensions and surrounding control flow.

## Related issue

Closes #909

## Validation

- `pytest -q quantecon/tests/test_lss.py quantecon/tests/test_kalman.py quantecon/markov/tests/test_random.py quantecon/game_theory/tests/test_normal_form_game.py quantecon/game_theory/game_generators/tests/test_bimatrix_generators.py` — 109 passed
- `flake8 --select=F401,F405,E231 quantecon` — passed
- `git diff --check` — passed
- Verified no remaining in-place `.shape =` assignments in Python sources.

## Notes

- A full `pytest quantecon -q` run reached 68% without failures but exceeded the 10-minute runner limit.
- The available environment resolved NumPy 2.4.6, so the NumPy 2.5-specific warning could not be exercised locally.
- This contribution was prepared with automated assistance and reviewed before submission.