### PR TITLE
CI: Measure Numba JIT coverage in a single dedicated job

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@
 relative_files = True
 source = quantecon
 omit =
+    # Exclude the test tree from the headline figure
+    */tests/*
     */python?.?/*
     */lib-python/?.?/*.py
     */lib_pypy/_*.py
@@ -29,10 +31,3 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
-
-    # Don't count Numba nopython=True jit functions
-    @jit
-    @jit\(.*nopython=True
-    @njit
-    @overload
-    @guvectorize\(.*nopython=True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,48 @@ jobs:
     - name: Run Tests (pytest)
       shell: bash -l {0}
       run: |
+        pytest quantecon
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+    - name: Cache conda
+      uses: actions/cache@v6
+      env:
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-3.13-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+    - uses: conda-incubator/setup-miniconda@v4
+      with:
+        auto-update-conda: true
+        miniforge-version: latest
+        environment-file: environment.yml
+        python-version: "3.13"
+        auto-activate-base: false
+        use-only-tar-bz2: true
+        activate-environment: qe
+    - name: Run Tests with coverage
+      shell: bash -l {0}
+      env:
+        # Numba emits coverage for JIT functions at compile time (lowering),
+        # which cache=True functions skip when loaded from a warm on-disk
+        # cache. Enable JIT coverage and point the cache at a throwaway dir
+        # so every jitted function is compiled -- and thus reported -- here.
+        # Requires numba >= 0.62 (coverage respects .coveragerc from there on).
+        NUMBA_JIT_COVERAGE: "1"
+        NUMBA_CACHE_DIR: ${{ runner.temp }}/numba_cache
+      run: |
         coverage run -m pytest quantecon
         coverage lcov
     - name: Coveralls
       uses: coverallsapp/github-action@v2
-      # upload from one Linux job only (avoids the Coveralls parallel-build 422
-      # race); continue-on-error so an upload hiccup can't fail CI
-      if: runner.os == 'Linux' && matrix.python-version == '3.13'
+      # continue-on-error so an upload hiccup can't fail CI
       continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,8 @@ dependencies:
   - numpy
   - scipy
   - pandas
-  - numba
+  # >=0.62: JIT coverage (NUMBA_JIT_COVERAGE) respects .coveragerc from 0.62 on
+  - numba>=0.62
   - sympy
   - ipython
   - flake8


### PR DESCRIPTION
Closes #871

## Problem

Two defects in coverage measurement (details in #871):

1. `.coveragerc` listed the Numba decorators (`@jit`, `@njit`, `@overload`, `@guvectorize`) under `exclude_lines`. coverage.py excludes the **entire decorated function** when a decorator line matches, so ~1,700 statements of jitted code — the numerical core of the library — were invisible to coverage. `quantecon/optimize/root_finding.py` reported 100% while measuring 10 of its 212 statements.
2. `source = quantecon` included the test tree, inflating the headline figure.

## Approach

Instead of the `NUMBA_DISABLE_JIT=1` + `coverage combine` approach proposed in the issue, this uses **Numba's native JIT coverage** (`NUMBA_JIT_COVERAGE=1`, added in 0.61, fixed to respect the coverage configuration file in 0.62). It measures the real compiled code paths — including `@overload` and `@guvectorize` targets — requires no second suite run or result combining, and doesn't risk masking JIT-only failures the way disabling JIT does.

One subtlety: Numba emits coverage at compile time (during lowering), which `cache=True` functions skip when loaded from a warm on-disk cache. Nearly every jitted function here uses `cache=True`, so the coverage job points `NUMBA_CACHE_DIR` at a throwaway directory to force compilation.

## Changes

- **`.coveragerc`** — remove the five Numba decorator patterns from `exclude_lines`; add `*/tests/*` to `omit` so the reported figure measures library code only.
- **`.github/workflows/ci.yml`** — the 3 OS × 3 Python matrix now runs plain `pytest` (production configuration, no coverage overhead). A new single `coverage` job (ubuntu, Python 3.13) runs the suite once with `NUMBA_JIT_COVERAGE=1` and uploads to Coveralls. With one coverage producer, the old per-matrix Coveralls `if:` gate (which existed to avoid the parallel-upload race) is obsolete and dropped. The job reuses the ubuntu/3.13 conda cache.
- **`environment.yml`** — pin `numba>=0.62`; on older numba the env var would not respect `.coveragerc` and the reported total would silently drop by ~5 pp.

## Results

**The reported percentage falls from 93.77% to 90.55% — by design.** The old figure both excluded ~1,700 jitted statements and counted the test tree; the new number is the true source-only baseline (5,638 statements, 533 missed; 600 tests passing, measured locally with numba 0.63.1). Please read the Coveralls delta on this PR accordingly, not as a regression.

Per the issue's acceptance criteria, `quantecon/optimize/*` now reports statement counts matching the AST counts:

| Module | Measured before | Measured now |
| --- | --- | --- |
| `optimize/root_finding.py` | 10 | 212 |
| `optimize/nelder_mead.py` | 4 | 112 |
| `optimize/scalar_maximization.py` | 2 | 79 |
| `optimize/linprog_simplex.py` | 18 | 168 |

## Known caveat: `parallel=True` / `prange`

Functions compiled with `parallel=True` get partial rather than complete line attribution: the parfor pass rewrites the `prange` loop (and hoists some setup statements) into parallel gufunc constructs *before* the lowering phase where Numba emits coverage, so the rewritten instructions lose their source-line mapping. Concretely, in `gini_coefficient` (`quantecon/_inequality.py`, the library's only `prange` function) the loop **body** is correctly reported as covered, but the `for i in prange(n):` header and one hoisted setup line show as missed despite being executed — 2 spuriously-missed lines out of 5,638, included in the baseline above. Left as-is deliberately: an `exclude_lines` pattern for `prange(` would exclude the entire loop block (coverage.py excludes the whole block under an excluded compound statement), throwing away the body measurement we just gained.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
