### PR TITLE
FIX: Align random.draw size dispatch for numpy integers

### DIFF
--- a/quantecon/random/tests/test_utilities.py
+++ b/quantecon/random/tests/test_utilities.py
@@ -90,6 +90,17 @@ class TestDraw:
             out = func(self.cdf, size)
             assert_(out.shape == (size,))
 
+    def test_numpy_integer_size_returns_array(self):
+        size = np.int64(10)
+        for func in self.draw_funcs:
+            out = func(self.cdf, size)
+            assert_(out.shape == (size,))
+
+    def test_bool_size_is_treated_as_scalar(self):
+        for func in self.draw_funcs:
+            out = func(self.cdf, True)
+            assert_(isinstance(out, numbers.Integral))
+
     def test_return_values(self):
         for func in self.draw_funcs:
             out = func(self.cdf)

--- a/quantecon/random/tests/test_utilities.py
+++ b/quantecon/random/tests/test_utilities.py
@@ -125,6 +125,17 @@ class TestDraw:
             out = func(self.cdf, size)
             assert_(out.shape == (size,))
 
+    def test_numpy_integer_size_returns_array(self):
+        size = np.int64(10)
+        for func in self.draw_funcs:
+            out = func(self.cdf, size)
+            assert_(out.shape == (size,))
+
+    def test_bool_size_is_treated_as_scalar(self):
+        for func in self.draw_funcs:
+            out = func(self.cdf, True)
+            assert_(isinstance(out, numbers.Integral))
+
     def test_return_values(self):
         for func in self.draw_funcs:
             out = func(self.cdf)

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -246,7 +246,11 @@ def draw(cdf, size=None, rng=None):
     """
     if rng is None:
         rng = np.random
-    if isinstance(size, int):
+    integer_size = (
+        isinstance(size, (int, np.integer))
+        and not isinstance(size, (bool, np.bool_))
+    )
+    if integer_size:
         rs = rng.random(size)
         out = np.searchsorted(cdf, rs, side='right')
         return out
@@ -287,8 +291,9 @@ def _is_no_rng(numba_type):
 # holds the two paths together.
 @overload(draw)
 def ol_draw(cdf, size=None, rng=None):
+    is_integer_size = isinstance(size, types.Integer) and not isinstance(size, types.Boolean)
     if isinstance(rng, types.NumPyRandomGeneratorType):
-        if isinstance(size, types.Integer):
+        if is_integer_size:
             def draw_impl(cdf, size=None, rng=None):
                 rs = rng.random(size)
                 out = np.empty(size, dtype=np.int_)
@@ -300,7 +305,7 @@ def ol_draw(cdf, size=None, rng=None):
                 r = rng.random()
                 return np.searchsorted(cdf, r, side='right')
     elif _is_no_rng(rng):
-        if isinstance(size, types.Integer):
+        if is_integer_size:
             def draw_impl(cdf, size=None, rng=None):
                 rs = np.random.random(size)
                 out = np.empty(size, dtype=np.int_)

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -198,7 +198,11 @@ def draw(cdf, size=None):
     array([1, 0, 1, 0, 1, 0, 0, 0, 1, 0])
 
     """
-    if isinstance(size, int):
+    integer_size = (
+        isinstance(size, (int, np.integer))
+        and not isinstance(size, (bool, np.bool_))
+    )
+    if integer_size:
         rs = np.random.random(size)
         out = np.searchsorted(cdf, rs, side='right')
         return out
@@ -210,7 +214,7 @@ def draw(cdf, size=None):
 # Overload for the `draw` function
 @overload(draw)
 def ol_draw(cdf, size=None):
-    if isinstance(size, types.Integer):
+    if isinstance(size, types.Integer) and not isinstance(size, types.Boolean):
         def draw_impl(cdf, size=None):
             rs = np.random.random(size)
             out = np.empty(size, dtype=np.int_)


### PR DESCRIPTION
Closes #918.

## Summary
- Treat numpy integer sizes (for example `np.int64(10)`) the same as Python `int` in the pure-Python `random.draw` path.
- Keep boolean `size` values on the scalar branch so Python and jitted dispatch agree.
- Add focused regression tests covering Python and `@njit` callers for both cases.

## Test plan
- [x] RED: `pytest quantecon/random/tests/test_utilities.py::TestDraw::test_numpy_integer_size_returns_array quantecon/random/tests/test_utilities.py::TestDraw::test_bool_size_is_treated_as_scalar -q` failed with the Python path returning a scalar for `np.int64(10)` and raising `TypeError` for `True`.
- [x] GREEN: same focused command passed: `2 passed in 6.43s`.
- [x] `pytest quantecon/random/tests/test_utilities.py -q` — `11 passed in 4.45s`.
- [x] `pytest quantecon/random -q` — `11 passed in 4.54s`.
- [x] `pytest quantecon -q` — `602 passed, 2 warnings in 504.77s`.
- [x] `flake8 --select=F401,F405,E231 quantecon`.
- [x] `git diff --check`.
