### PR TITLE
FIX: remove unused numerical locals

### DIFF
--- a/quantecon/_kalman.py
+++ b/quantecon/_kalman.py
@@ -158,7 +158,7 @@ class Kalman:
         K = self.K_infinity
 
         # Get the matrix sizes
-        n, k, m, l = self.ss.n, self.ss.k, self.ss.m, self.ss.l
+        n, m, l = self.ss.n, self.ss.m, self.ss.l
         A, C, G, H = self.ss.A, self.ss.C, self.ss.G, self.ss.H
 
         Atil = np.vstack([np.hstack([A, np.zeros((n, n)), np.zeros((n, l))]),

--- a/quantecon/_lss.py
+++ b/quantecon/_lss.py
@@ -391,7 +391,7 @@ class LinearStateSpace:
             The coefficients for y
         """
         # Pull out matrices
-        A, C, G, H = self.A, self.C, self.G, self.H
+        A, C, G = self.A, self.C, self.G
         Apower = np.copy(A)
 
         # Create room for coefficients

--- a/quantecon/_matrix_eqn.py
+++ b/quantecon/_matrix_eqn.py
@@ -272,7 +272,7 @@ def solve_discrete_riccati_system(Π, As, Bs, Cs, Qs, Rs, Ns, beta,
 
     """
     m = Qs.shape[0]
-    k, n = Qs.shape[1], Rs.shape[1]
+    n = Rs.shape[1]
     # Create the Ps matrices, initialize as identity matrix
     Ps = np.array([np.eye(n) for i in range(m)])
     Ps1 = np.copy(Ps)

--- a/quantecon/_robustlq.py
+++ b/quantecon/_robustlq.py
@@ -242,8 +242,8 @@ class RBLQ:
 
         """
         # == Simplify names == #
-        A, B, C, Q, R = self.A, self.B, self.C, self.Q, self.R
-        beta, theta = self.beta, self.theta
+        A, B, C = self.A, self.B, self.C
+        theta = self.theta
         # == Set up loop == #
         P = np.zeros((self.n, self.n)) if P_init is None else P_init
         iterate, e = 0, tol + 1
@@ -381,7 +381,7 @@ class RBLQ:
 
         """
         # == Simplify names == #
-        Q, R, A, B, C = self.Q, self.R, self.A, self.B, self.C
+        A, B, C = self.A, self.B, self.C
         beta, theta = self.beta, self.theta
 
         # == Solve for policies and costs using agent 2's problem == #


### PR DESCRIPTION
## Summary
- Remove the reviewed unused locals from the numerical modules listed in #883.
- Leave the surrounding numerical logic unchanged; each removed binding was only a stale local alias or unused tuple element.

## Verification
- RED: `ruff check quantecon/_robustlq.py quantecon/_kalman.py quantecon/_lss.py quantecon/_matrix_eqn.py --select F841` reported the eight unused-local findings from #883.
- GREEN: `ruff check quantecon/_robustlq.py quantecon/_kalman.py quantecon/_lss.py quantecon/_matrix_eqn.py --select F841`
- `pytest quantecon/tests/test_kalman.py quantecon/tests/test_lss.py quantecon/tests/test_matrix_eqn.py quantecon/tests/test_robustlq.py -q` (22 passed)
- `pytest quantecon/tests -q` (221 passed)

Closes #883.
