### PR TITLE
FIX: Point README star history chart to a working mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ pages = {5585}
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=quantecon/quantecon.py&type=Date)](https://star-history.com/#quantecon/quantecon.py&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=quantecon/quantecon.py&type=Date)](https://star-history.dera.page/#quantecon/quantecon.py&type=Date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken, as the upstream project can no longer read the GitHub stargazer API. This updates the badge and link to star-history.dera.page, a mirror that uses a token-free data source, so the chart shows correctly again.