### PR TITLE
WASM: Disable Gini parallelization on Emscripten

### DIFF
--- a/quantecon/_inequality.py
+++ b/quantecon/_inequality.py
@@ -3,8 +3,13 @@ Implements inequality and segregation measures such as Gini, Lorenz Curve
 
 """
 
+import sys
+
 import numpy as np
 from numba import njit, prange
+
+
+PARALLELIZE = sys.platform != "emscripten"
 
 
 @njit
@@ -54,7 +59,7 @@ def lorenz_curve(y):
     return cum_people, cum_income
 
 
-@njit(parallel=True)
+@njit(parallel=PARALLELIZE)
 def gini_coefficient(y):
     r"""
     Implements the Gini inequality index
@@ -152,4 +157,3 @@ def rank_size(data, c=1.0):
     rank_data = np.arange(len(w)) + 1
     size_data = w
     return rank_data, size_data
-


### PR DESCRIPTION
Closes #926

## Summary

- disable Numba's parallel accelerator for `gini_coefficient` on Emscripten;
- keep the existing parallel path on native platforms.

The browser Numba runtime is single-threaded and cannot compile this library's only `@njit(parallel=True)` function. Selecting the decorator option from `sys.platform` lets `prange` use its serial semantics in JupyterLite without changing the public API or native behavior.

## Validation

- `python -m pytest -q quantecon/tests/test_inequality.py` — 4 passed
- `python -m flake8 --select=F401,F405,E231 quantecon` — passed
- Native Python 3.13: compiled target reports `parallel=True`
- Simulated Emscripten import: compiled target reports `parallel=False`; `gini_coefficient([1, 2, 3]) == 2/9`
- `git diff --check` — passed

Automated assistance was used to prepare and validate this change.
