### PR TITLE
BUG: Return -1 from best_response_2p instead of falling through to None

### DIFF
--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -915,8 +915,9 @@ def best_response_2p(payoff_matrix, opponent_mixed_action, tol=1e-8):
     Returns
     -------
     scalar(int)
-        Best response action; -1 if there is no action that satisfies
-        the tolerance condition, which occurs only if `tol` < 0.
+        Best response action. -1 indicates an error condition: no
+        action satisfies the tolerance condition, which occurs only
+        if `tol` < 0.
 
     """
     n, m = payoff_matrix.shape

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -909,13 +909,15 @@ def best_response_2p(payoff_matrix, opponent_mixed_action, tol=1e-8):
         Opponent's mixed action. Its length must be equal to
         `payoff_matrix.shape[1]`.
 
-    tol : scalar(float), optional(default=None)
-        Tolerance level used in determining best responses.
+    tol : scalar(float), optional(default=1e-8)
+        Tolerance level used in determining best responses. Must be
+        nonnegative.
 
     Returns
     -------
     scalar(int)
-        Best response action.
+        Best response action; -1 if there is no action that satisfies
+        the tolerance condition, which occurs only if `tol` < 0.
 
     """
     n, m = payoff_matrix.shape
@@ -932,3 +934,5 @@ def best_response_2p(payoff_matrix, opponent_mixed_action, tol=1e-8):
     for a in range(n):
         if payoff_vector[a] >= payoff_max - tol:
             return a
+
+    return -1  # Unreachable unless tol < 0

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -910,7 +910,8 @@ def best_response_2p(payoff_matrix, opponent_mixed_action, tol=1e-8):
         `payoff_matrix.shape[1]`.
 
     tol : scalar(float), optional(default=1e-8)
-        Tolerance level used in determining best responses.
+        Tolerance level used in determining best responses. Must be
+        nonnegative.
 
     Returns
     -------

--- a/quantecon/game_theory/normal_form_game.py
+++ b/quantecon/game_theory/normal_form_game.py
@@ -910,8 +910,7 @@ def best_response_2p(payoff_matrix, opponent_mixed_action, tol=1e-8):
         `payoff_matrix.shape[1]`.
 
     tol : scalar(float), optional(default=1e-8)
-        Tolerance level used in determining best responses. Must be
-        nonnegative.
+        Tolerance level used in determining best responses.
 
     Returns
     -------

--- a/quantecon/game_theory/tests/test_normal_form_game.py
+++ b/quantecon/game_theory/tests/test_normal_form_game.py
@@ -556,3 +556,12 @@ def test_best_response_2p():
             br_computed = \
                 best_response_2p(test_case['payoff_array'], mixed_action)
             assert_(br_computed == br_expected)
+
+
+def test_best_response_2p_negative_tol():
+    # With tol < 0 no action can satisfy the tolerance condition;
+    # -1 is returned rather than falling through to None
+    payoff_array = np.array([[4., 0.], [3., 2.]])
+    mixed_action = np.array([0.5, 0.5])
+    br_computed = best_response_2p(payoff_array, mixed_action, tol=-1e-8)
+    assert_(br_computed == -1)


### PR DESCRIPTION
Extracts the one standalone fix from the long-open PR #576 (see discussion there), so it can land independently of the type-annotation policy decision in #897.

`best_response_2p` documents an `int` return, but when `tol < 0` no action satisfies the tolerance condition and the final loop falls through to an implicit `None`. Per @oyamad's suggestion in the #576 review discussion, the function now returns `-1` in that case and the docstring documents the behavior (and corrects the stated default for `tol`, which is `1e-8`, not `None`).

This is hardening rather than a live bug: no internal caller passes a negative `tol`. A regression test covering the `tol < 0` case is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)