### PR TITLE
CI: Update Numba to 0.67 release version

### DIFF
--- a/environment_np2.yml
+++ b/environment_np2.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy>=2
   - scipy
   - pandas
-  - numba=0.67.0rc1
+  - numba>=0.67
   - sympy
   - ipython
   - flake8


### PR DESCRIPTION
https://numba.discourse.group/t/ann-numba-0-67-and-llvmlite-0-49-final-numpy-2-5-and-windows-arm64-support