### PR TITLE
WASM: defer eager Numba gufunc/jit compilation to first use (#930)

### DIFF
--- a/quantecon/game_theory/vertex_enumeration.py
+++ b/quantecon/game_theory/vertex_enumeration.py
@@ -296,25 +296,33 @@ class _BestResponsePolytope:
         self.trans_recip = trans_recip
 
 
-@guvectorize(['(i4[:], u8[:])'], '(m)->()', nopython=True, cache=True)
-def _ints_arr_to_bits(ints_arr, out):
+def _ints_arr_to_bits_kernel(ints_arr, out):  # pragma: no cover
+    m = ints_arr.shape[0]
+    out[0] = 0
+    for i in range(m):
+        out[0] |= np.uint64(1) << np.uint64(ints_arr[i])
+
+
+_ints_arr_to_bits_gufunc = None
+
+
+def _ints_arr_to_bits(ints_arr):
     """
     Convert an array of integers representing the set bits into the
     corresponding integer.
 
-    Compiled as a ufunc by Numba's `@guvectorize`: if the input is a
-    2-dim array with shape[0]=K, the function returns a 1-dim array of
-    K converted integers.
+    If the input is a 2-dim array with shape[0]=K, returns a 1-dim array
+    of K converted integers.
 
     Parameters
     ----------
-    ints_arr : ndarray(int32, ndim=1)
+    ints_arr : ndarray(int32, ndim=1 or 2)
         Array of distinct integers from 0, ..., 63.
 
     Returns
     -------
-    np.uint64
-        Integer with set bits represented by the input integers.
+    np.uint64 or ndarray(uint64)
+        Integer(s) with set bits represented by the input integers.
 
     Examples
     --------
@@ -326,10 +334,12 @@ def _ints_arr_to_bits(ints_arr, out):
     array([ 7, 11], dtype=uint64)
 
     """
-    m = ints_arr.shape[0]
-    out[0] = 0
-    for i in range(m):
-        out[0] |= np.uint64(1) << np.uint64(ints_arr[i])
+    global _ints_arr_to_bits_gufunc
+    if _ints_arr_to_bits_gufunc is None:
+        _ints_arr_to_bits_gufunc = guvectorize(
+            ['(i4[:], u8[:])'], '(m)->()', nopython=True, cache=True
+        )(_ints_arr_to_bits_kernel)
+    return _ints_arr_to_bits_gufunc(ints_arr)
 
 
 @jit(nopython=True, cache=True)

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -89,14 +89,26 @@ def _probvec(r, out):  # pragma: no cover
         out[i] = r[i] - r[i-1]
     out[n] = 1 - r[n-1]
 
-_probvec_parallel = guvectorize(
-    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='parallel',
-    cache=True
-    )(_probvec)
-_probvec_cpu = guvectorize(
-    ['(f8[:], f8[:])'], '(n), (k)', nopython=True, target='cpu',
-    cache=True
-    )(_probvec)
+_probvec_parallel_gufunc = None
+_probvec_cpu_gufunc = None
+
+
+def _probvec_parallel(r, out):
+    global _probvec_parallel_gufunc
+    if _probvec_parallel_gufunc is None:
+        _probvec_parallel_gufunc = guvectorize(
+            ['(f8[:], f8[:])'], '(n),(k)', nopython=True,
+            target='parallel', cache=True)(_probvec)
+    _probvec_parallel_gufunc(r, out)
+
+
+def _probvec_cpu(r, out):
+    global _probvec_cpu_gufunc
+    if _probvec_cpu_gufunc is None:
+        _probvec_cpu_gufunc = guvectorize(
+            ['(f8[:], f8[:])'], '(n),(k)', nopython=True,
+            target='cpu', cache=True)(_probvec)
+    _probvec_cpu_gufunc(r, out)
 
 
 def sample_without_replacement(n, k, num_trials=None, random_state=None):
@@ -153,10 +165,9 @@ def sample_without_replacement(n, k, num_trials=None, random_state=None):
     return result
 
 
-@guvectorize(['(i8, f8[:], i8[:])'], '(),(k)->(k)', nopython=True, cache=True)
-def _sample_without_replacement(n, r, out):
+def _sample_without_replacement_kernel(n, r, out):  # pragma: no cover
     """
-    Main body of `sample_without_replacement`. To be complied as a ufunc
+    Main body of `sample_without_replacement`. To be compiled as a ufunc
     by guvectorize of Numba.
 
     """
@@ -168,6 +179,18 @@ def _sample_without_replacement(n, r, out):
         idx = np.intp(np.floor(r[j] * (n-j)))  # np.floor returns a float
         out[j] = pool[idx]
         pool[idx] = pool[n-j-1]
+
+
+_swr_gufunc = None
+
+
+def _sample_without_replacement(n, r):
+    global _swr_gufunc
+    if _swr_gufunc is None:
+        _swr_gufunc = guvectorize(
+            ['(i8, f8[:], i8[:])'], '(),(k)->(k)', nopython=True, cache=True
+        )(_sample_without_replacement_kernel)
+    return _swr_gufunc(n, r)
 
 
 # Pure python implementation that will run if the JIT compiler is disabled


### PR DESCRIPTION
Closes #930, part of #925.

### What

Four guvectorize callables compiled at `import quantecon` time are now compiled lazily on first call:

| Callable | File | Change |
|---|---|---|
| `_probvec_parallel` | `random/utilities.py` | module-level gufunc → lazy Python wrapper |
| `_probvec_cpu` | `random/utilities.py` | same |
| `_sample_without_replacement` | `random/utilities.py` | `@guvectorize` decorator → lazy wrapper |
| `_ints_arr_to_bits` | `game_theory/vertex_enumeration.py` | same |

### How

Gufuncs are replaced by thin Python wrapper functions that create the underlying ufunc on first call and cache it in a module-level sentinel. `_probvec_cpu` keeps the same name so the `game_theory/random.py` import is unchanged.

### Why this matters for WASM

On native CPython, eager compilation costs milliseconds. In a JupyterLite/WASM kernel, each compile is a full LLVM optimise + WASM object emit + in-process LLD link. The emscripten-forge Numba patches also force-disable `cache=True` for `@guvectorize`, so the four gufunc compiles were paid on every session on the critical import path of every notebook.

### Public API

No change. `qe.random.probvec(..., parallel=...)`, `qe.random.sample_without_replacement(...)`, and `qe.game_theory.vertex_enumeration(...)` are unaffected.