### PR TITLE
MAINT: vendor rng_integers helper

### DIFF
--- a/quantecon/util/random.py
+++ b/quantecon/util/random.py
@@ -5,8 +5,101 @@ Utilities to Support Random State Infrastructure
 import numpy as np
 import numbers
 
-# To be called as util.rng_integers
-from scipy._lib._util import rng_integers  # noqa: F401
+# Adapted from SciPy's ``rng_integers`` implementation:
+# https://github.com/scipy/scipy/blob/v1.17.1/scipy/_lib/_util.py
+# Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+def rng_integers(gen, low, high=None, size=None, dtype='int64',
+                 endpoint=False):
+    """
+    Return random integers from low (inclusive) to high (exclusive), or if
+    endpoint=True, low (inclusive) to high (inclusive). Replaces
+    `RandomState.randint` (with endpoint=False) and
+    `RandomState.random_integers` (with endpoint=True).
+
+    Return random integers from the "discrete uniform" distribution of the
+    specified dtype. If high is None (the default), then results are from
+    0 to low.
+
+    Parameters
+    ----------
+    gen : {None, np.random.RandomState, np.random.Generator}
+        Random number generator. If None, then the np.random.RandomState
+        singleton is used.
+    low : int or array-like of ints
+        Lowest (signed) integers to be drawn from the distribution (unless
+        high=None, in which case this parameter is 0 and this value is used
+        for high).
+    high : int or array-like of ints
+        If provided, one above the largest (signed) integer to be drawn from
+        the distribution (see above for behavior if high=None). If array-like,
+        must contain integer values.
+    size : array-like of ints, optional
+        Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
+        samples are drawn. Default is None, in which case a single value is
+        returned.
+    dtype : {str, dtype}, optional
+        Desired dtype of the result. All dtypes are determined by their name,
+        i.e., 'int64', 'int', etc, so byteorder is not available and a specific
+        precision may have different C types depending on the platform.
+        The default value is 'int64'.
+    endpoint : bool, optional
+        If True, sample from the interval [low, high] instead of the default
+        [low, high) Defaults to False.
+
+    Returns
+    -------
+    out: int or ndarray of ints
+        size-shaped array of random integers from the appropriate distribution,
+        or a single such random int if size not provided.
+    """
+    if isinstance(gen, np.random.Generator):
+        return gen.integers(low, high=high, size=size, dtype=dtype,
+                            endpoint=endpoint)
+    else:
+        if gen is None:
+            # default is RandomState singleton used by np.random.
+            gen = np.random.mtrand._rand
+        if endpoint:
+            # inclusive of endpoint
+            # remember that low and high can be arrays, so don't modify in
+            # place
+            if high is None:
+                return gen.randint(low + 1, size=size, dtype=dtype)
+            if high is not None:
+                return gen.randint(low, high=high + 1, size=size, dtype=dtype)
+
+        # exclusive
+        return gen.randint(low, high=high, size=size, dtype=dtype)
 
 
 # Random States

--- a/quantecon/util/tests/test_random.py
+++ b/quantecon/util/tests/test_random.py
@@ -1,0 +1,106 @@
+"""Tests for random state utilities."""
+
+import ast
+import inspect
+from pathlib import Path
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from quantecon.util import random as random_utils
+from quantecon.util import rng_integers
+
+
+def _expected_random_state_call(random_state, low, high, size, dtype, endpoint):
+    if high is None:
+        high = low + 1 if endpoint else low
+        return random_state.randint(high, size=size, dtype=dtype)
+    if endpoint:
+        high += 1
+    return random_state.randint(low, high=high, size=size, dtype=dtype)
+
+
+def test_rng_integers_has_no_private_scipy_import():
+    source = Path(random_utils.__file__).read_text()
+    tree = ast.parse(source)
+    private_module = '.'.join(('scipy', '_lib', '_util'))
+    private_imports = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == private_module
+    ]
+    assert not private_imports
+
+
+def test_rng_integers_signature_is_stable():
+    assert str(inspect.signature(rng_integers)) == (
+        "(gen, low, high=None, size=None, dtype='int64', endpoint=False)"
+    )
+
+
+def test_rng_integers_matches_random_state():
+    cases = [
+        (0, 10, (32,), np.int64, False),
+        (-5, 5, (32,), np.int32, True),
+        (4, None, 32, np.int16, True),
+    ]
+
+    for low, high, size, dtype, endpoint in cases:
+        actual = rng_integers(
+            np.random.RandomState(12345),
+            low,
+            high=high,
+            size=size,
+            dtype=dtype,
+            endpoint=endpoint,
+        )
+        expected = _expected_random_state_call(
+            np.random.RandomState(12345),
+            low,
+            high,
+            size,
+            dtype,
+            endpoint,
+        )
+        assert_array_equal(actual, expected)
+        assert actual.dtype == np.dtype(dtype)
+
+
+def test_rng_integers_matches_generator():
+    cases = [
+        (0, 10, (32,), np.int64, False),
+        (-5, 5, (32,), np.int32, True),
+        (4, None, 32, np.int16, True),
+    ]
+
+    for low, high, size, dtype, endpoint in cases:
+        actual = rng_integers(
+            np.random.default_rng(12345),
+            low,
+            high=high,
+            size=size,
+            dtype=dtype,
+            endpoint=endpoint,
+        )
+        expected = np.random.default_rng(12345).integers(
+            low,
+            high=high,
+            size=size,
+            dtype=dtype,
+            endpoint=endpoint,
+        )
+        assert_array_equal(actual, expected)
+        assert actual.dtype == np.dtype(dtype)
+
+
+def test_rng_integers_none_uses_random_state_singleton():
+    original_state = np.random.get_state()
+    try:
+        np.random.seed(12345)
+        actual = rng_integers(None, -3, high=4, size=32, endpoint=True)
+        np.random.seed(12345)
+        expected = np.random.randint(-3, high=5, size=32)
+    finally:
+        np.random.set_state(original_state)
+
+    assert_array_equal(actual, expected)


### PR DESCRIPTION
Fixes #868.

Replaces the private SciPy import with the BSD-licensed `rng_integers` implementation and adds compatibility coverage for `RandomState`, `Generator`, and the global NumPy random state.

Tests:
- `pytest quantecon/util/tests/test_random.py` (5 passed)
- `flake8 --select=F401,F405,E231 quantecon`
- Full suite: 653 passed; the notebook dependency test failed while connecting to `raw.githubusercontent.com`.