### PR TITLE
MAINT: Remove the sympy dependency

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -3,7 +3,6 @@ ipython
 numpydoc
 numba>=0.49
 numpy>=1.17
-sympy
 scipy>=1.5
 requests
 matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - pandas
   # >=0.62: JIT coverage (NUMBA_JIT_COVERAGE) respects .coveragerc from 0.62 on
   - numba>=0.62
-  - sympy
   - ipython
   - flake8
   - requests

--- a/environment_np2.yml
+++ b/environment_np2.yml
@@ -11,7 +11,6 @@ dependencies:
   - scipy
   - pandas
   - numba>=0.67
-  - sympy
   - ipython
   - flake8
   - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     'numpy>=1.17.0',
     'requests',
     'scipy>=1.5.0',
-    'sympy',
 ]
 
 [project.optional-dependencies]
@@ -39,7 +38,6 @@ testing = [
     "scipy",
     "pandas",
     "numba",
-    "sympy",
 ]
 
 

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -211,8 +211,7 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
 
 def _primes_below(n):
     """
-    Return all primes strictly less than n (the upper bound is
-    exclusive, matching sympy.primerange(0, n)), by the Sieve of
+    Return all primes strictly less than n, by the Sieve of
     Eratosthenes.
 
     """

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -168,8 +168,7 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     random_state = check_random_state(random_state)
 
     if equidist_pp is None:
-        import sympy as sym
-        equidist_pp = np.sqrt(np.array(list(sym.primerange(0, 7920))))
+        equidist_pp = np.sqrt(_primes_upto(7920))
 
     n, a, b = list(map(np.atleast_1d, list(map(np.asarray, [n, a, b]))))
 
@@ -208,6 +207,19 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     weights = (np.prod(r) / n) * np.ones(n)
 
     return nodes, weights
+
+
+def _primes_upto(n):
+    """
+    Return all primes up to n, by the Sieve of Eratosthenes.
+
+    """
+    sieve = np.ones(n, dtype=bool)
+    sieve[:2] = False
+    for i in range(2, int(n**0.5) + 1):
+        if sieve[i]:
+            sieve[i*i::i] = False
+    return np.flatnonzero(sieve)
 
 
 def qnwlege(n, a, b):

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -168,7 +168,7 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     random_state = check_random_state(random_state)
 
     if equidist_pp is None:
-        equidist_pp = np.sqrt(_primes_upto(7920))
+        equidist_pp = np.sqrt(_primes_below(7920))
 
     n, a, b = list(map(np.atleast_1d, list(map(np.asarray, [n, a, b]))))
 
@@ -209,9 +209,11 @@ def qnwequi(n, a, b, kind="N", equidist_pp=None, random_state=None):
     return nodes, weights
 
 
-def _primes_upto(n):
+def _primes_below(n):
     """
-    Return all primes up to n, by the Sieve of Eratosthenes.
+    Return all primes strictly less than n (the upper bound is
+    exclusive, matching sympy.primerange(0, n)), by the Sieve of
+    Eratosthenes.
 
     """
     sieve = np.ones(n, dtype=bool)

--- a/quantecon/quad.py
+++ b/quantecon/quad.py
@@ -217,7 +217,7 @@ def _primes_below(n):
     """
     sieve = np.ones(n, dtype=bool)
     sieve[:2] = False
-    for i in range(2, int(n**0.5) + 1):
+    for i in range(2, math.isqrt(n) + 1):
         if sieve[i]:
             sieve[i*i::i] = False
     return np.flatnonzero(sieve)

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -18,7 +18,7 @@ import pandas as pd
 from quantecon.quad import (
     qnwcheb, qnwequi, qnwlege, qnwnorm, qnwlogn,
     qnwsimp, qnwtrap, qnwunif, quadrect, qnwbeta,
-    qnwgamma, _primes_upto
+    qnwgamma, _primes_below
 )
 from quantecon.tests.util import get_data_dir
 
@@ -502,10 +502,10 @@ class TestQnwgamm:
         assert_allclose(self.w_gamm_3, data['w_gamm_3'])
 
 
-def test_primes_upto():
+def test_primes_below():
     # Invariants of the first 1000 primes (= sympy.primerange(0, 7920)),
     # on which qnwequi's Weyl and Haber sequences depend
-    primes = _primes_upto(7920)
+    primes = _primes_below(7920)
     assert len(primes) == 1000
     assert_array_equal(primes[:5], [2, 3, 5, 7, 11])
     assert primes[99] == 541       # 100th prime
@@ -513,5 +513,5 @@ def test_primes_upto():
     assert primes[-1] == 7919      # 1000th prime
     assert primes.sum() == 3682913
     # The upper bound is exclusive, matching primerange(0, n)
-    assert_array_equal(_primes_upto(2), [])
-    assert_array_equal(_primes_upto(3), [2])
+    assert_array_equal(_primes_below(2), [])
+    assert_array_equal(_primes_below(3), [2])

--- a/quantecon/tests/test_quad.py
+++ b/quantecon/tests/test_quad.py
@@ -13,12 +13,12 @@ a section of comments.
 import os
 from scipy.io import loadmat
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 import pandas as pd
 from quantecon.quad import (
     qnwcheb, qnwequi, qnwlege, qnwnorm, qnwlogn,
     qnwsimp, qnwtrap, qnwunif, quadrect, qnwbeta,
-    qnwgamma
+    qnwgamma, _primes_upto
 )
 from quantecon.tests.util import get_data_dir
 
@@ -500,3 +500,18 @@ class TestQnwgamm:
 
     def test_qnwgamm_weights_3d(self):
         assert_allclose(self.w_gamm_3, data['w_gamm_3'])
+
+
+def test_primes_upto():
+    # Invariants of the first 1000 primes (= sympy.primerange(0, 7920)),
+    # on which qnwequi's Weyl and Haber sequences depend
+    primes = _primes_upto(7920)
+    assert len(primes) == 1000
+    assert_array_equal(primes[:5], [2, 3, 5, 7, 11])
+    assert primes[99] == 541       # 100th prime
+    assert primes[499] == 3571     # 500th prime
+    assert primes[-1] == 7919      # 1000th prime
+    assert primes.sum() == 3682913
+    # The upper bound is exclusive, matching primerange(0, n)
+    assert_array_equal(_primes_upto(2), [])
+    assert_array_equal(_primes_upto(3), [2])


### PR DESCRIPTION
Resolve the `sympy` half of #880:

* Replace `sympy.primerange(0, 7920)` in `qnwequi` with a custom implementation `_primes_upto` (Claude Code Fable 5 recommended the most primitive algorithm).
* This allows us to remove the `sympy` dependency.