### PR TITLE
WASM: raise OSError for network calls on Emscripten (#931)

### DIFF
--- a/ci/wasm/smoke_test.py
+++ b/ci/wasm/smoke_test.py
@@ -229,7 +229,25 @@ def test_simplex_grid():
 
 
 # ---------------------------------------------------------------------------
-# 13. searchsorted — objmode() shim (deprecated helper)
+# 13. Network utilities — raise OSError on Emscripten (#931)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not IS_EMSCRIPTEN, reason="Emscripten-only guard check")
+def test_fetch_nb_dependencies_raises_on_emscripten():
+    from quantecon.util import fetch_nb_dependencies
+    with pytest.raises(OSError, match="unavailable in the browser"):
+        fetch_nb_dependencies(["dummy.csv"])
+
+
+@pytest.mark.skipif(not IS_EMSCRIPTEN, reason="Emscripten-only guard check")
+def test_gam_reader_from_url_raises_on_emscripten():
+    from quantecon.game_theory.game_converters import GAMReader
+    with pytest.raises(OSError, match="unavailable in the browser"):
+        GAMReader.from_url("http://example.com/dummy.gam")
+
+
+# ---------------------------------------------------------------------------
+# 15. searchsorted — objmode() shim (deprecated helper)
 # ---------------------------------------------------------------------------
 
 def test_searchsorted():

--- a/quantecon/game_theory/game_converters.py
+++ b/quantecon/game_theory/game_converters.py
@@ -204,7 +204,20 @@ class GAMReader:
         """
         Read from a URL.
 
+        Raises
+        ------
+        OSError
+            On Emscripten (JupyterLite/xeus-python), where HTTP socket access
+            is unavailable.
+
         """
+        if sys.platform == "emscripten":
+            raise OSError(
+                "GAMReader.from_url requires HTTP socket access, which is "
+                "unavailable in the browser (Emscripten/xeus-python). "
+                "Use GAMReader.from_string or GAMReader.from_file with "
+                "pre-downloaded data instead."
+            )
         import urllib.request
         with urllib.request.urlopen(url) as response:
             string = response.read().decode()

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -33,7 +33,8 @@ def probvec(m, k, random_state=None, parallel=True):
     parallel : bool(default=True)
         Whether to use multi-core CPU (parallel=True) or single-threaded
         CPU (parallel=False). (Internally the code is executed through
-        Numba.guvectorize.)
+        Numba.guvectorize.) On Emscripten (JupyterLite), parallel=True
+        executes serially via the Numba emscripten-forge patch 0007.
 
     Returns
     -------

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -20,6 +20,7 @@ TODO
 """
 
 import os
+import sys
 
 #-Remote Structure-#
 REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
@@ -71,6 +72,13 @@ def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDE
     by setting ``overwrite=True``.
 
     """
+    if sys.platform == "emscripten":
+        raise OSError(
+            "fetch_nb_dependencies requires HTTP socket access, which is "
+            "unavailable in the browser (Emscripten/xeus-python). "
+            "Pre-download the required files before running in JupyterLite."
+        )
+
     import requests
 
     #-Generate Common Data Structure-#


### PR DESCRIPTION
Closes #931.

- `fetch_nb_dependencies` and `GAMReader.from_url` now raise `OSError` with a descriptive message on `sys.platform == "emscripten"` instead of failing with a cryptic socket error.
- `probvec` docstring notes that `parallel=True` executes serially on Emscripten via Numba patch 0007.
- Two `smoke_test.py` tests verify the new errors fire in the browser kernel (skipped on native).