### PR TITLE
FIX: Pivoting routines: Report numerical breakdown correctly

### DIFF
--- a/quantecon/_compute_fp.py
+++ b/quantecon/_compute_fp.py
@@ -256,7 +256,7 @@ def _compute_fixed_point_ig(T, v, max_iter, verbose, print_skip, is_approx_fp,
         tableaux_curr = tuple(tableau[:m, :2*m+1] for tableau in tableaux)
         bases_curr = tuple(basis[:m] for basis in bases)
         _initialize_tableaux_ig(X[:m], Y[:m], tableaux_curr, bases_curr)
-        converged, num_iter = _lemke_howson_tbl(
+        converged, num_iter, _ = _lemke_howson_tbl(
             tableaux_curr, bases_curr, init_pivot=m-1, max_iter=max_piv
         )
         _, rho = _get_mixed_actions(tableaux_curr, bases_curr)

--- a/quantecon/_compute_fp.py
+++ b/quantecon/_compute_fp.py
@@ -37,6 +37,8 @@ def _print_after_skip(skip, it=None, dist=None, etime=None):
 _convergence_msg = 'Converged in {iterate} steps'
 _non_convergence_msg = \
     'max_iter attained before convergence in compute_fixed_point'
+_breakdown_msg = \
+    'numerical breakdown in the imitation game in compute_fixed_point'
 
 
 def _is_approx_fp(T, v, error_tol, *args, **kwargs):
@@ -223,6 +225,7 @@ def _compute_fixed_point_ig(T, v, max_iter, verbose, print_skip, is_approx_fp,
     tableaux = tuple(np.empty((buff_size, buff_size*2+1)) for i in range(2))
     bases = tuple(np.empty(buff_size, dtype=int) for i in range(2))
     max_piv = 10**6  # Max number of pivoting steps in _lemke_howson_tbl
+    breakdown = False
 
     while True:
         y_new = T(x_new, *args, **kwargs)
@@ -256,9 +259,11 @@ def _compute_fixed_point_ig(T, v, max_iter, verbose, print_skip, is_approx_fp,
         tableaux_curr = tuple(tableau[:m, :2*m+1] for tableau in tableaux)
         bases_curr = tuple(basis[:m] for basis in bases)
         _initialize_tableaux_ig(X[:m], Y[:m], tableaux_curr, bases_curr)
-        converged, num_iter, _ = _lemke_howson_tbl(
+        _, _, breakdown = _lemke_howson_tbl(
             tableaux_curr, bases_curr, init_pivot=m-1, max_iter=max_piv
         )
+        if breakdown:  # The tableaux do not hold an equilibrium
+            break
         _, rho = _get_mixed_actions(tableaux_curr, bases_curr)
 
         if Y.ndim <= 2:
@@ -274,7 +279,9 @@ def _compute_fixed_point_ig(T, v, max_iter, verbose, print_skip, is_approx_fp,
         print_skip = 1
         _print_after_skip(print_skip, iterate, error, etime)
     if verbose >= 1:
-        if not converged:
+        if breakdown:
+            warnings.warn(_breakdown_msg, RuntimeWarning)
+        elif not converged:
             warnings.warn(_non_convergence_msg, RuntimeWarning)
         elif verbose == 2:
             print(_convergence_msg.format(iterate=iterate))

--- a/quantecon/game_theory/howson_lcp.py
+++ b/quantecon/game_theory/howson_lcp.py
@@ -176,9 +176,16 @@ def polym_lcp_solver(
                 break
             num_iter += 1
 
-            _, pivrow = _lex_min_ratio_test(
+            found, pivrow, resolved = _lex_min_ratio_test(
                 tableau, pivcol, 0, argmins,
             )
+            if not (found and resolved):
+                # Numerical breakdown: no positive entry in the pivot
+                # column, or lexicographic tie not broken, both
+                # impossible in exact arithmetic; stop with
+                # `converged = False`
+                converging = False
+                break
 
             _pivoting(tableau, pivcol, pivrow)
             basis[pivrow], leaving_var = pivcol, basis[pivrow]

--- a/quantecon/game_theory/howson_lcp.py
+++ b/quantecon/game_theory/howson_lcp.py
@@ -68,7 +68,8 @@ def polym_lcp_solver(
     -------
     NE : tuple(ndarray(float, ndim=1))
         Tuple of computed Nash equilibrium mixed actions. A Nash
-        Equilibrium if not stopped early by reaching `max_iter`.
+        Equilibrium if not stopped early by reaching `max_iter` or by a
+        numerical breakdown of the pivoting.
 
     res : NashResult
         Object containing information about the computation: the number

--- a/quantecon/game_theory/lemke_howson.py
+++ b/quantecon/game_theory/lemke_howson.py
@@ -394,11 +394,15 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
     while True:
         for pl in pls:
             # Determine the leaving variable
-            found, row_min = _lex_min_ratio_test(tableaux[pl], pivot,
-                                                 slack_starts[pl], argmins)
-            if not found:  # Numerical breakdown: no positive entry in
-                break      # the pivot column, impossible in exact
-                           # arithmetic; stop with `converged = False`
+            found, row_min, resolved = _lex_min_ratio_test(
+                tableaux[pl], pivot, slack_starts[pl], argmins
+            )
+            if not (found and resolved):
+                # Numerical breakdown: no positive entry in the pivot
+                # column, or lexicographic tie not broken, both
+                # impossible in exact arithmetic; stop with
+                # `converged = False`
+                break
 
             # Pivoting step: modify tableau in place
             _pivoting(tableaux[pl], pivot, row_min)

--- a/quantecon/game_theory/lemke_howson.py
+++ b/quantecon/game_theory/lemke_howson.py
@@ -198,12 +198,15 @@ def _lemke_howson_capping(payoff_matrices, tableaux, bases, init_pivot,
         capping_curr = min(max_iter_curr, capping)
 
         _initialize_tableaux(payoff_matrices, tableaux, bases)
-        converged, num_iter = \
+        converged, num_iter, breakdown = \
             _lemke_howson_tbl(tableaux, bases, init_pivot_curr, capping_curr)
 
         total_num_iter += num_iter
 
         if converged or total_num_iter >= max_iter:
+            return converged, total_num_iter, init_pivot_curr
+        if breakdown and capping >= max_iter:
+            # Capping not enabled: do not try another initial pivot
             return converged, total_num_iter, init_pivot_curr
 
         init_pivot_curr += 1
@@ -212,7 +215,7 @@ def _lemke_howson_capping(payoff_matrices, tableaux, bases, init_pivot,
         max_iter_curr -= num_iter
 
     _initialize_tableaux(payoff_matrices, tableaux, bases)
-    converged, num_iter = \
+    converged, num_iter, _ = \
         _lemke_howson_tbl(tableaux, bases, init_pivot_curr, max_iter_curr)
     total_num_iter += num_iter
 
@@ -346,6 +349,11 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
     num_iter : scalar(int)
         Number of pivoting steps performed.
 
+    breakdown : bool
+        Whether the pivoting stopped because of a numerical breakdown
+        (no positive entry in the pivot column, or lexicographic tie not
+        broken, neither of which can happen in exact arithmetic).
+
     Examples
     --------
     >>> np.set_printoptions(precision=4)  # Reduce the digits printed
@@ -356,7 +364,7 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
     >>> bases = (np.empty(n, dtype=int), np.empty(m, dtype=int))
     >>> tableaux, bases = _initialize_tableaux((A, B), tableaux, bases)
     >>> _lemke_howson_tbl(tableaux, bases, 1, 10)
-    (True, 4)
+    (True, 4, False)
     >>> tableaux[0]
     array([[ 0.875 ,  0.    ,  1.    ,  0.375 , -0.125 ,  0.25  ],
            [ 0.1875,  1.    ,  0.    , -0.0625,  0.1875,  0.125 ]])
@@ -389,6 +397,7 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
     argmins = np.empty(max(m, n), dtype=np.int_)
 
     converged = False
+    breakdown = False
     num_iter = 0
 
     while True:
@@ -402,6 +411,7 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
                 # column, or lexicographic tie not broken, both
                 # impossible in exact arithmetic; stop with
                 # `converged = False`
+                breakdown = True
                 break
 
             # Pivoting step: modify tableau in place
@@ -421,7 +431,7 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
             continue
         break
 
-    return converged, num_iter
+    return converged, num_iter, breakdown
 
 
 @jit(nopython=True, cache=True)

--- a/quantecon/game_theory/lemke_howson.py
+++ b/quantecon/game_theory/lemke_howson.py
@@ -394,8 +394,11 @@ def _lemke_howson_tbl(tableaux, bases, init_pivot, max_iter):
     while True:
         for pl in pls:
             # Determine the leaving variable
-            _, row_min = _lex_min_ratio_test(tableaux[pl], pivot,
-                                             slack_starts[pl], argmins)
+            found, row_min = _lex_min_ratio_test(tableaux[pl], pivot,
+                                                 slack_starts[pl], argmins)
+            if not found:  # Numerical breakdown: no positive entry in
+                break      # the pivot column, impossible in exact
+                           # arithmetic; stop with `converged = False`
 
             # Pivoting step: modify tableau in place
             _pivoting(tableaux[pl], pivot, row_min)

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -146,6 +146,9 @@ def test_lemke_howson_large_payoffs_report_breakdown(scale):
     g = NormalFormGame((Player(A), Player(B)))
     NE, res = lemke_howson(g, full_output=True)
     assert_(not res.converged)
+    # Without capping, no other initial pivot is tried on breakdown
+    assert_(res.init == 0)
+    assert_(res.num_iter == 0)
 
 
 def test_lemke_howson_tbl_breakdown():
@@ -160,6 +163,8 @@ def test_lemke_howson_tbl_breakdown():
     _initialize_tableaux((A, B), tableaux, bases)
     init_pivot = 0
     tableaux[0][:, init_pivot] = 0
-    converged, num_iter = _lemke_howson_tbl(tableaux, bases, init_pivot, 10)
+    converged, num_iter, breakdown = \
+        _lemke_howson_tbl(tableaux, bases, init_pivot, 10)
     assert_(not converged)
     assert_(num_iter == 0)
+    assert_(breakdown)

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -133,21 +133,19 @@ def test_lemke_howson_invalid_init_pivot_float():
     assert_raises(TypeError, lemke_howson, g, 1.0)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="`tol_ratio_diff` in the lexico-minimum ratio test is absolute, "
-           "so with payoffs of order 1e16 the ratios all tie",
-)
-def test_lemke_howson_scaled_game_returns_nash():
-    scale = 1e16
+@pytest.mark.parametrize('scale', [1e15, 1e16])
+def test_lemke_howson_large_payoffs_report_breakdown(scale):
+    # With payoffs of this size, the ratios in the lexico-minimum ratio
+    # test all tie within the (absolute) `tol_ratio_diff`, and the tie
+    # breaking fails. The routine must then report non-convergence
+    # rather than return a wrong "equilibrium" with `converged=True`.
     A = scale * np.array([[3., 1.],
                           [1., 3.]])
     B = scale * np.array([[1., 3.],
                           [3., 1.]])
-    g = NormalFormGame((A, B))
+    g = NormalFormGame((Player(A), Player(B)))
     NE, res = lemke_howson(g, full_output=True)
-    assert_(res.converged)
-    assert_(g.is_nash(NE))
+    assert_(not res.converged)
 
 
 def test_lemke_howson_tbl_breakdown():

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -2,6 +2,7 @@
 Tests for lemke_howson.py
 """
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_, assert_raises
 from quantecon.game_theory import Player, NormalFormGame, lemke_howson
 
@@ -127,3 +128,20 @@ def test_lemke_howson_invalid_init_pivot_float():
                 [(0, 3), (6, 1)]]
     g = NormalFormGame(bimatrix)
     assert_raises(TypeError, lemke_howson, g, 1.0)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="`tol_ratio_diff` in the lexico-minimum ratio test is absolute, "
+           "so with payoffs of order 1e16 the ratios all tie",
+)
+def test_lemke_howson_scaled_game_returns_nash():
+    scale = 1e16
+    A = scale * np.array([[3., 1.],
+                          [1., 3.]])
+    B = scale * np.array([[1., 3.],
+                          [3., 1.]])
+    g = NormalFormGame((A, B))
+    NE, res = lemke_howson(g, full_output=True)
+    assert_(res.converged)
+    assert_(g.is_nash(NE))

--- a/quantecon/game_theory/tests/test_lemke_howson.py
+++ b/quantecon/game_theory/tests/test_lemke_howson.py
@@ -5,6 +5,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_, assert_raises
 from quantecon.game_theory import Player, NormalFormGame, lemke_howson
+from quantecon.game_theory.lemke_howson import (
+    _initialize_tableaux, _lemke_howson_tbl
+)
 
 
 class TestLemkeHowson():
@@ -145,3 +148,20 @@ def test_lemke_howson_scaled_game_returns_nash():
     NE, res = lemke_howson(g, full_output=True)
     assert_(res.converged)
     assert_(g.is_nash(NE))
+
+
+def test_lemke_howson_tbl_breakdown():
+    # No positive entry in the column of the initial pivot: the routine
+    # must stop and report non-convergence rather than pivot on a
+    # meaningless row
+    A = np.array([[3, 3], [2, 5], [0, 6]])
+    B = np.array([[3, 2, 3], [2, 6, 1]])
+    m, n = A.shape
+    tableaux = (np.empty((n, m+n+1)), np.empty((m, m+n+1)))
+    bases = (np.empty(n, dtype=int), np.empty(m, dtype=int))
+    _initialize_tableaux((A, B), tableaux, bases)
+    init_pivot = 0
+    tableaux[0][:, init_pivot] = 0
+    converged, num_iter = _lemke_howson_tbl(tableaux, bases, init_pivot, 10)
+    assert_(not converged)
+    assert_(num_iter == 0)

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -196,9 +196,10 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
     return LCPResult(z, success, status, num_iter)
 
 
-lcp_lemke.__doc__ = lcp_lemke.__doc__.format(
-    FEA_TOL=FEA_TOL, TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
-)
+if lcp_lemke.__doc__ is not None:  # None under python -OO
+    lcp_lemke.__doc__ = lcp_lemke.__doc__.format(
+        FEA_TOL=FEA_TOL, TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
+    )
 
 
 @jit(nopython=True, cache=True)

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -133,6 +133,8 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
 
     if d is None:
         d = np.ones(n)
+    elif not np.all(d > 0):
+        raise ValueError('d must be strictly positive')
     if tableau is None:
         tableau = np.empty((n, 2*n+2))
     if basis is None:
@@ -143,14 +145,20 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
     art_var = 2*n  # Artificial variable
     pivcol = art_var
 
-    # Equivalent to lex_min_ratio_test
+    # Equivalent to lex_min_ratio_test: the lexicographic tie breaking
+    # reduces to taking the largest row index, as the slack columns form
+    # the identity matrix. Ties are measured against the smallest ratio
+    # found so far, which is not updated on a tie, so that the accepted
+    # set cannot drift away from the minimum by chaining tolerances.
     pivrow = 0
     ratio_min = q[0] / d[0]
     for i in range(1, n):
         ratio = q[i] / d[i]
-        if ratio <= ratio_min + piv_options.tol_ratio_diff:
+        if ratio < ratio_min - piv_options.tol_ratio_diff:  # Smaller
             pivrow = i
             ratio_min = ratio
+        elif ratio <= ratio_min + piv_options.tol_ratio_diff:  # Tie
+            pivrow = i
 
     _pivoting(tableau, pivcol, pivrow)
     basis[pivrow], pivcol = pivcol, pivrow + n
@@ -281,7 +289,7 @@ def _get_solution(tableau, basis, z):
         View to `z`.
 
     """
-    n = z.size
+    n = basis.shape[0]
 
     z[:] = 0
     for i in range(n):

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -91,6 +91,7 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
                     0 : Solution found successfully
                     1 : Iteration limit reached
                     2 : Secondary ray termination
+                    3 : Numerical difficulties encountered
 
             num_iter : int
                 The number of iterations performed.
@@ -168,7 +169,7 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
     argmins = np.empty(n, dtype=np.int_)
 
     while num_iter < max_iter:
-        pivrow_found, pivrow, _ = _lex_min_ratio_test(
+        pivrow_found, pivrow, resolved = _lex_min_ratio_test(
             tableau, pivcol, 0, argmins,
             piv_options.tol_piv, piv_options.tol_ratio_diff
         )
@@ -176,6 +177,10 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
         if not pivrow_found:  # Ray termination
             success = False
             status = 2
+            break
+        if not resolved:  # Numerical breakdown: lexicographic tie not
+            success = False  # broken, impossible in exact arithmetic
+            status = 3
             break
 
         _pivoting(tableau, pivcol, pivrow)

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -117,6 +117,8 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
 
     """
     n = M.shape[0]
+    if d is not None and not np.all(d > 0):
+        raise ValueError('d must be strictly positive')
 
     success = False
     status = 1
@@ -133,8 +135,6 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
 
     if d is None:
         d = np.ones(n)
-    elif not np.all(d > 0):
-        raise ValueError('d must be strictly positive')
     if tableau is None:
         tableau = np.empty((n, 2*n+2))
     if basis is None:

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -148,14 +148,14 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
 
     # Equivalent to lex_min_ratio_test: the lexicographic tie breaking
     # reduces to taking the largest row index, as the slack columns form
-    # the identity matrix. Ties are measured against the smallest ratio
-    # found so far, which is not updated on a tie, so that the accepted
-    # set cannot drift away from the minimum by chaining tolerances.
+    # the identity matrix. Ties are measured against the minimum ratio
+    # found so far, updated on every strictly smaller ratio, so that the
+    # row chosen is the last one within the tolerance of the minimum.
     pivrow = 0
     ratio_min = q[0] / d[0]
     for i in range(1, n):
         ratio = q[i] / d[i]
-        if ratio < ratio_min - piv_options.tol_ratio_diff:  # Smaller
+        if ratio < ratio_min:  # Smaller
             pivrow = i
             ratio_min = ratio
         elif ratio <= ratio_min + piv_options.tol_ratio_diff:  # Tie

--- a/quantecon/optimize/lcp_lemke.py
+++ b/quantecon/optimize/lcp_lemke.py
@@ -160,7 +160,7 @@ def lcp_lemke(M, q, d=None, max_iter=10**6, piv_options=PivOptions(),
     argmins = np.empty(n, dtype=np.int_)
 
     while num_iter < max_iter:
-        pivrow_found, pivrow = _lex_min_ratio_test(
+        pivrow_found, pivrow, _ = _lex_min_ratio_test(
             tableau, pivcol, 0, argmins,
             piv_options.tol_piv, piv_options.tol_ratio_diff
         )

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -599,13 +599,19 @@ def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
     tol_piv = piv_options.tol_piv
     for i in range(L):
         if basis[i] >= nm:  # Artificial variable not eliminated
+            # Pivot on the largest entry (in absolute value) of the row,
+            # if treated as nonzero
+            j_max = -1
+            v_max = tol_piv
             for j in range(nm):
-                if tableau[i, j] < -tol_piv or \
-                   tableau[i, j] > tol_piv:  # Treated nonzero
-                    _pivoting(tableau, j, i)
-                    basis[i] = j
-                    num_iter_1 += 1
-                    break
+                v = abs(tableau[i, j])
+                if v > v_max:
+                    v_max = v
+                    j_max = j
+            if j_max >= 0:
+                _pivoting(tableau, j_max, i)
+                basis[i] = j_max
+                num_iter_1 += 1
 
     return success, status, num_iter_1
 

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -540,7 +540,7 @@ def solve_tableau(tableau, basis, max_iter=10**6, skip_aux=True,
             break
 
         aux_start = tableau.shape[1] - L - 1
-        pivrow_found, pivrow = _lex_min_ratio_test(
+        pivrow_found, pivrow, _ = _lex_min_ratio_test(
             tableau[:-1, :], pivcol, aux_start, argmins,
             piv_options.tol_piv, piv_options.tol_ratio_diff
         )

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -581,13 +581,16 @@ def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
     L = tableau.shape[0] - 1
     nm = tableau.shape[1] - (L+1)  # n + m
 
+    # Scale of the right hand side, for the feasibility test below: the
+    # initial value of the Phase 1 objective is the sum of |b|
+    b_scale = max(1., tableau[-1, -1])
     success, status, num_iter_1 = \
         solve_tableau(tableau, basis, max_iter, skip_aux=False,
                       piv_options=piv_options)
 
     if not success:  # max_iter exceeded
         return success, status, num_iter_1
-    if tableau[-1, -1] > piv_options.fea_tol:  # Infeasible
+    if tableau[-1, -1] > piv_options.fea_tol * b_scale:  # Infeasible
         success = False
         status = 2
         return success, status, num_iter_1

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -233,7 +233,9 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
                 ndarray of shape (L,) containing the dual solution.
 
             fun : float
-                Value of the objective function.
+                Value of the objective function (-inf if the problem
+                appears to be infeasible, inf if it appears to be
+                unbounded).
 
             success : bool
                 True if the algorithm succeeded in finding an optimal
@@ -285,6 +287,8 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
         solve_phase_1(tableau, basis, max_iter, piv_options=piv_options)
     num_iter += num_iter_1
     if not success:
+        if status == 3:  # Unbounded
+            fun = np.inf
         return SimplexResult(x, lambd, fun, success, status, num_iter)
 
     # Modify the criterion row for Phase 2
@@ -296,6 +300,8 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
                       piv_options=piv_options)
     num_iter += num_iter_2
     fun = get_solution(tableau, basis, x, lambd, b_signs)
+    if status == 3:  # Unbounded
+        fun = np.inf
 
     return SimplexResult(x, lambd, fun, success, status, num_iter)
 
@@ -607,7 +613,7 @@ def _pivot_col(tableau, skip_aux, piv_options):
     containing the maximum positive element in the last row of the
     tableau.
 
-    `skip_aux` should be True in phase 1, and False in phase 2.
+    `skip_aux` should be False in phase 1, and True in phase 2.
 
     Parameters
     ----------
@@ -673,7 +679,7 @@ def get_solution(tableau, basis, x, lambd, b_signs):
 
     b_signs : ndarray(bool, ndim=1)
         ndarray of shape (L,) whose i-th element is True iff the i-th
-        element of the vector (b_ub, b_eq) is positive.
+        element of the vector (b_ub, b_eq) is nonnegative.
 
     Returns
     -------
@@ -681,7 +687,7 @@ def get_solution(tableau, basis, x, lambd, b_signs):
         The optimal value.
 
     """
-    n, L = x.size, lambd.size
+    n, L = x.size, basis.size
     aux_start = tableau.shape[1] - L - 1
 
     x[:] = 0

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -249,6 +249,7 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
                     1 : Iteration limit reached
                     2 : Problem appears to be infeasible
                     3 : Problem appears to be unbounded
+                    4 : Numerical difficulties encountered
 
             num_iter : int
                 The number of iterations performed.
@@ -547,7 +548,7 @@ def solve_tableau(tableau, basis, max_iter=10**6, skip_aux=True,
             break
 
         aux_start = tableau.shape[1] - L - 1
-        pivrow_found, pivrow, _ = _lex_min_ratio_test(
+        pivrow_found, pivrow, resolved = _lex_min_ratio_test(
             tableau[:-1, :], pivcol, aux_start, argmins,
             piv_options.tol_piv, piv_options.tol_ratio_diff
         )
@@ -555,6 +556,10 @@ def solve_tableau(tableau, basis, max_iter=10**6, skip_aux=True,
         if not pivrow_found:  # Unbounded
             success = False
             status = 3
+            break
+        if not resolved:  # Numerical breakdown: lexicographic tie not
+            success = False  # broken, impossible in exact arithmetic
+            status = 4
             break
 
         _pivoting(tableau, pivcol, pivrow)
@@ -588,7 +593,10 @@ def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
         solve_tableau(tableau, basis, max_iter, skip_aux=False,
                       piv_options=piv_options)
 
-    if not success:  # max_iter exceeded
+    if not success:
+        if status == 3:
+            # The auxiliary problem is bounded: a numerical breakdown
+            status = 4
         return success, status, num_iter_1
     if tableau[-1, -1] > piv_options.fea_tol * b_scale:  # Infeasible
         success = False

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -306,9 +306,10 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
     return SimplexResult(x, lambd, fun, success, status, num_iter)
 
 
-linprog_simplex.__doc__ = linprog_simplex.__doc__.format(
-    FEA_TOL=FEA_TOL, TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
-)
+if linprog_simplex.__doc__ is not None:  # None under python -OO
+    linprog_simplex.__doc__ = linprog_simplex.__doc__.format(
+        FEA_TOL=FEA_TOL, TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
+    )
 
 
 @jit(nopython=True, cache=True)

--- a/quantecon/optimize/linprog_simplex.py
+++ b/quantecon/optimize/linprog_simplex.py
@@ -288,8 +288,6 @@ def linprog_simplex(c, A_ub=np.empty((0, 0)), b_ub=np.empty((0,)),
         solve_phase_1(tableau, basis, max_iter, piv_options=piv_options)
     num_iter += num_iter_1
     if not success:
-        if status == 3:  # Unbounded
-            fun = np.inf
         return SimplexResult(x, lambd, fun, success, status, num_iter)
 
     # Modify the criterion row for Phase 2
@@ -586,9 +584,11 @@ def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
     L = tableau.shape[0] - 1
     nm = tableau.shape[1] - (L+1)  # n + m
 
-    # Scale of the right hand side, for the feasibility test below: the
-    # initial value of the Phase 1 objective is the sum of |b|
+    # Scales of the right hand side, for the feasibility tests below: the
+    # initial value of the Phase 1 objective is the sum of |b|, and the
+    # initial values of the basic variables are |b_k|
     b_scale = max(1., tableau[-1, -1])
+    b_abs = tableau[:L, -1].copy()
     success, status, num_iter_1 = \
         solve_tableau(tableau, basis, max_iter, skip_aux=False,
                       piv_options=piv_options)
@@ -602,6 +602,17 @@ def solve_phase_1(tableau, basis, max_iter=10**6, piv_options=PivOptions()):
         success = False
         status = 2
         return success, status, num_iter_1
+    # The artificial variable of constraint k enters that constraint only,
+    # so its level is the residual of the constraint: test each one still
+    # basic against the scale of its own constraint, as the total above
+    # can hide a violation of a constraint with a small right hand side
+    for i in range(L):
+        if basis[i] >= nm:  # Artificial variable of constraint k
+            k = basis[i] - nm
+            if tableau[i, -1] > piv_options.fea_tol * max(1., b_abs[k]):
+                success = False  # Infeasible
+                status = 2
+                return success, status, num_iter_1
 
     # Check artificial variables have been eliminated
     tol_piv = piv_options.tol_piv

--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -105,26 +105,27 @@ def _min_ratio_test_no_tie_breaking(tableau, pivot, test_col,
         Number of minimizing rows.
 
     """
+    # Ties are measured against the exact minimum ratio, determined in a
+    # first pass, so that the accepted set cannot drift away from the
+    # minimum by chaining tolerances
     ratio_min = np.inf
-    num_argmins = 0
-
-    # `ratio_min` is deliberately not updated when a tie is recorded:
-    # ties are measured against the smallest ratio found so far, not
-    # against the last tied ratio, so that the accepted set cannot drift
-    # away from the minimum by chaining tolerances.
     for k in range(num_candidates):
         i = argmins[k]
         if tableau[i, pivot] <= tol_piv:  # Treated as nonpositive
             continue
         ratio = tableau[i, test_col] / tableau[i, pivot]
-        if ratio > ratio_min + tol_ratio_diff:  # Ratio large for i
-            continue
-        elif ratio < ratio_min - tol_ratio_diff:  # Ratio smaller for i
+        if ratio < ratio_min:
             ratio_min = ratio
-            num_argmins = 1
-        else:  # Ratio equal
+
+    num_argmins = 0
+    for k in range(num_candidates):
+        i = argmins[k]
+        if tableau[i, pivot] <= tol_piv:  # Treated as nonpositive
+            continue
+        ratio = tableau[i, test_col] / tableau[i, pivot]
+        if ratio <= ratio_min + tol_ratio_diff:  # Ratio minimal for i
             num_argmins += 1
-        argmins[num_argmins-1] = i
+            argmins[num_argmins-1] = i
 
     return num_argmins
 

--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -157,10 +157,14 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
     Returns
     -------
     found : bool
-        False if there is no positive entry in the pivot column.
+        False if there is no positive entry in the pivot column (up to
+        `tol_piv`), True otherwise.
 
     row_min : scalar(int)
-        Index of the row with the lexico-minimum ratio.
+        Index of the row with the lexico-minimum ratio. If the
+        lexicographic tie breaking fails to single out one row, which
+        can only happen when the remaining candidate rows are
+        indistinguishable within `tol_ratio_diff`, the first of them.
 
     """
     nrows = tableau.shape[0]
@@ -175,9 +179,16 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
     num_argmins = _min_ratio_test_no_tie_breaking(
         tableau, pivot, -1, argmins, num_candidates, tol_piv, tol_ratio_diff
     )
-    if num_argmins == 1:
-        found = True
-    elif num_argmins >= 2:
+    if num_argmins == 0:  # No positive entry in the pivot column
+        return found, argmins[0]
+
+    # `found` is True from here: the pivot column has a positive entry.
+    # The lexicographic passes below only refine the choice among the
+    # rows that tie in the ratio test; if they fail to single out one
+    # row, the remaining candidates are numerically indistinguishable
+    # (they cannot be linearly dependent), and the first is taken.
+    found = True
+    if num_argmins >= 2:
         for j in range(slack_start, slack_start+nrows):
             if j == pivot:
                 continue
@@ -186,8 +197,8 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
                 tol_piv, tol_ratio_diff
             )
             if num_argmins == 1:
-                found = True
                 break
+
     return found, argmins[0]
 
 

--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -108,6 +108,10 @@ def _min_ratio_test_no_tie_breaking(tableau, pivot, test_col,
     ratio_min = np.inf
     num_argmins = 0
 
+    # `ratio_min` is deliberately not updated when a tie is recorded:
+    # ties are measured against the smallest ratio found so far, not
+    # against the last tied ratio, so that the accepted set cannot drift
+    # away from the minimum by chaining tolerances.
     for k in range(num_candidates):
         i = argmins[k]
         if tableau[i, pivot] <= tol_piv:  # Treated as nonpositive
@@ -161,10 +165,29 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
         `tol_piv`), True otherwise.
 
     row_min : scalar(int)
-        Index of the row with the lexico-minimum ratio. If the
-        lexicographic tie breaking fails to single out one row, which
-        can only happen when the remaining candidate rows are
-        indistinguishable within `tol_ratio_diff`, the first of them.
+        Index of the row with the lexico-minimum ratio (meaningless if
+        `found` is False). If the lexicographic tie breaking fails to
+        single out one row, which can only happen when the remaining
+        candidate rows are indistinguishable within `tol_ratio_diff`,
+        the first of them.
+
+    resolved : bool
+        True if `row_min` is the unique lexico-minimum row, False if
+        `found` is False or the tie breaking failed to single out one
+        row. In exact arithmetic the latter cannot happen (the rows of
+        the tableau restricted to the slack columns are linearly
+        independent), so `found and not resolved` signals a numerical
+        breakdown that callers may want to act on.
+
+    Notes
+    -----
+    The last column of `tableau` must contain the values of the basic
+    variables (the right hand side), and the columns `slack_start`, ...,
+    `slack_start+nrows-1` must be those that initially formed an identity
+    matrix (typically the slack or artificial variables), so that they
+    contain the inverse of the current basis matrix: the lexicographic
+    rule breaks the ties in the ratio test by comparing these columns in
+    order.
 
     """
     nrows = tableau.shape[0]
@@ -180,7 +203,7 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
         tableau, pivot, -1, argmins, num_candidates, tol_piv, tol_ratio_diff
     )
     if num_argmins == 0:  # No positive entry in the pivot column
-        return found, argmins[0]
+        return found, argmins[0], False
 
     # `found` is True from here: the pivot column has a positive entry.
     # The lexicographic passes below only refine the choice among the
@@ -198,8 +221,9 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
             )
             if num_argmins == 1:
                 break
+    resolved = num_argmins == 1
 
-    return found, argmins[0]
+    return found, argmins[0], resolved
 
 
 _lex_min_ratio_test.__doc__ = _lex_min_ratio_test.__doc__.format(

--- a/quantecon/optimize/pivoting.py
+++ b/quantecon/optimize/pivoting.py
@@ -226,6 +226,7 @@ def _lex_min_ratio_test(tableau, pivot, slack_start, argmins,
     return found, argmins[0], resolved
 
 
-_lex_min_ratio_test.__doc__ = _lex_min_ratio_test.__doc__.format(
-    TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
-)
+if _lex_min_ratio_test.__doc__ is not None:  # None under python -OO
+    _lex_min_ratio_test.__doc__ = _lex_min_ratio_test.__doc__.format(
+        TOL_PIV=TOL_PIV, TOL_RATIO_DIFF=TOL_RATIO_DIFF
+    )

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -126,6 +126,9 @@ def test_lcp_lemke_nonpositive_d():
     q = np.array([-1., -1.])
     assert_raises(ValueError, lcp_lemke, M, q, np.array([1., 0.]))
     assert_raises(ValueError, lcp_lemke, M, q, np.array([1., -1.]))
+    # Also in the trivial case, where d is not used
+    q_trivial = np.array([1., 1.])
+    assert_raises(ValueError, lcp_lemke, M, q_trivial, np.array([1., 0.]))
 
 
 def test_lcp_lemke_workspaces():

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -140,3 +140,17 @@ def test_lcp_lemke_workspaces():
     assert_(res.success)
     assert_allclose(M @ res.z + q, np.zeros(n) + (M @ res.z + q).clip(0))
     assert_allclose(res.z @ (M @ res.z + q), 0, atol=1e-12)
+
+
+def test_lcp_lemke_numerical_breakdown():
+    # Entries of order 1e14: the lexicographic tie breaking fails within
+    # `tol_ratio_diff`; an arbitrary pivot led to a wrong "solution"
+    # reported as success
+    s = 2e14
+    M = np.array([[-1., -4., 1.],
+                  [-5*s, s, 3*s],
+                  [-5*s, 3*s, s]])
+    q = -np.ones(3)
+    res = lcp_lemke(M, q)
+    assert_(not res.success)
+    assert_equal(res.status, 3)

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -3,7 +3,9 @@ Tests for lcp_lemke
 
 """
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import (
+    assert_, assert_allclose, assert_equal, assert_raises
+)
 
 from quantecon.optimize import lcp_lemke
 
@@ -117,3 +119,21 @@ class TestLCPLemke:
         q = rng.standard_normal(n)
         res = lcp_lemke(M, q)
         _assert_success(res, M, q)
+
+
+def test_lcp_lemke_nonpositive_d():
+    M = np.array([[2., 1.], [1., 2.]])
+    q = np.array([-1., -1.])
+    assert_raises(ValueError, lcp_lemke, M, q, np.array([1., 0.]))
+    assert_raises(ValueError, lcp_lemke, M, q, np.array([1., -1.]))
+
+
+def test_lcp_lemke_workspaces():
+    M = np.array([[2., 1.], [1., 2.]])
+    q = np.array([-1., -1.])
+    n = 2
+    res = lcp_lemke(M, q, tableau=np.empty((n, 2*n+2)),
+                    basis=np.empty(n, dtype=int), z=np.empty(n))
+    assert_(res.success)
+    assert_allclose(M @ res.z + q, np.zeros(n) + (M @ res.z + q).clip(0))
+    assert_allclose(res.z @ (M @ res.z + q), 0, atol=1e-12)

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -154,3 +154,18 @@ def test_lcp_lemke_numerical_breakdown():
     res = lcp_lemke(M, q)
     assert_(not res.success)
     assert_equal(res.status, 3)
+
+
+def test_lcp_lemke_initial_ratio_test_anchored():
+    # Chained near-ties in the initial ratios q / d: the second is within
+    # `tol_ratio_diff` of the first, the third within the tolerance of the
+    # second but not of the first. Ties are measured against the minimum,
+    # so the artificial variable enters at row 1, not at row 2 (chaining).
+    # With max_iter=1 only the initial pivot is performed.
+    n, tol = 3, 1e-13
+    M = np.eye(n)
+    q = np.array([-3., -3. + 0.9*tol, -3. + 1.8*tol])
+    basis = np.empty(n, dtype=int)
+    res = lcp_lemke(M, q, basis=basis, max_iter=1)
+    assert_equal(res.status, 1)
+    assert_equal(basis[1], 2*n)  # Artificial variable

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -169,3 +169,10 @@ def test_lcp_lemke_initial_ratio_test_anchored():
     res = lcp_lemke(M, q, basis=basis, max_iter=1)
     assert_equal(res.status, 1)
     assert_equal(basis[1], 2*n)  # Artificial variable
+
+    # Decreasing then increasing: the second ratio is the minimum, the
+    # third is within the tolerance of the first but not of the minimum
+    q = np.array([-3., -3. - 0.9*tol, -3. + 0.9*tol])
+    res = lcp_lemke(M, q, basis=basis, max_iter=1)
+    assert_equal(res.status, 1)
+    assert_equal(basis[1], 2*n)  # Artificial variable

--- a/quantecon/optimize/tests/test_lcp_lemke.py
+++ b/quantecon/optimize/tests/test_lcp_lemke.py
@@ -144,8 +144,9 @@ def test_lcp_lemke_workspaces():
 
 def test_lcp_lemke_numerical_breakdown():
     # Entries of order 1e14: the lexicographic tie breaking fails within
-    # `tol_ratio_diff`; an arbitrary pivot led to a wrong "solution"
-    # reported as success
+    # `tol_ratio_diff`. This used to be reported as ray termination, and
+    # pivoting through the tie leads to a wrong "solution" reported as
+    # success; it is a numerical breakdown
     s = 2e14
     M = np.array([[-1., -4., 1.],
                   [-5*s, s, 3*s],

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -294,3 +294,26 @@ def test_linprog_simplex_workspaces():
                           x=np.empty(n), lambd=np.empty(L))
     assert_(res.success)
     assert_allclose(res.x, [0.5, 0.5])
+
+
+class TestLinprogSimplexPhase1Scale:
+    # The infeasibility test at the end of Phase 1 is relative to the
+    # scale of the right hand side
+    def test_feasible_relative_to_scale(self):
+        # Two equality constraints inconsistent by 1e-3, which is below
+        # fea_tol times the scale of b (2e5)
+        c = np.array([-1., -1.])
+        A_eq = np.array([[1., 1.], [1., 1.]])
+        b_eq = np.array([1e5, 1e5 + 1e-3])
+        res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
+        assert_(res.success)
+        assert_(res.status == 0)
+        assert_allclose(res.fun, -1e5, atol=1e-3)
+
+    def test_infeasible_at_unit_scale(self):
+        # The same inconsistency at scale 1 is infeasible
+        c = np.array([-1., -1.])
+        A_eq = np.array([[1., 1.], [1., 1.]])
+        b_eq = np.array([1., 1. + 1e-3])
+        res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
+        assert_(res.status == 2)

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -317,3 +317,13 @@ class TestLinprogSimplexPhase1Scale:
         b_eq = np.array([1., 1. + 1e-3])
         res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
         assert_(res.status == 2)
+
+
+def test_linprog_simplex_artificial_variables_at_zero():
+    # b = 0: Phase 1 ends immediately with the artificial variables
+    # basic at level zero, and they are pivoted out afterwards
+    c = np.array([-1., -1.])
+    A_eq = np.array([[1., 1.], [1., -1.]])
+    b_eq = np.array([0., 0.])
+    res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
+    _assert_success(res, c, b_eq=b_eq, desired_fun=0., desired_x=[0., 0.])

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -257,12 +257,13 @@ class TestLinprogSimplex:
         # x = 0 is the unique feasible, hence optimal, solution. The two
         # constraint rows tie in the lexico-minimum ratio test in all
         # columns within `tol_ratio_diff`, which used to be reported as
-        # "unbounded".
+        # "unbounded"; it is a numerical breakdown.
         c = np.array([1.])
         A_ub = np.array([[1e14], [1e14]])
         b_ub = np.zeros(2)
         res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
-        _assert_success(res, c, b_ub=b_ub, desired_fun=0., desired_x=[0.])
+        assert_(not res.success)
+        assert_(res.status == 4)
 
 
 class TestLinprogSimplexFailureOutputs:
@@ -327,3 +328,16 @@ def test_linprog_simplex_artificial_variables_at_zero():
     b_eq = np.array([0., 0.])
     res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
     _assert_success(res, c, b_eq=b_eq, desired_fun=0., desired_x=[0., 0.])
+
+
+def test_linprog_simplex_phase_1_breakdown_is_not_unbounded():
+    # Eleven identical equalities with coefficients at `tol_piv`: Phase 1
+    # finds no admissible pivot, which cannot mean unboundedness, as the
+    # auxiliary problem is bounded
+    c = np.array([1.])
+    A_eq = np.full((11, 1), 1e-7)
+    b_eq = np.full(11, 1e-7)
+    res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
+    assert_(not res.success)
+    assert_(res.status == 4)
+    assert_(res.fun != np.inf)

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -263,3 +263,34 @@ class TestLinprogSimplex:
         b_ub = np.zeros(2)
         res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
         _assert_success(res, c, b_ub=b_ub, desired_fun=0., desired_x=[0.])
+
+
+class TestLinprogSimplexFailureOutputs:
+    def test_infeasible(self):
+        # x >= 0 and x <= -1
+        res = linprog_simplex(np.array([1.]), A_ub=np.array([[1.]]),
+                              b_ub=np.array([-1.]))
+        assert_(res.status == 2)
+        assert_(res.fun == -np.inf)
+
+    def test_unbounded(self):
+        # max x0 s.t. x0 - x1 <= 1
+        res = linprog_simplex(np.array([1., 0.]), A_ub=np.array([[1., -1.]]),
+                              b_ub=np.array([1.]))
+        assert_(res.status == 3)
+        assert_(res.fun == np.inf)
+        assert_(np.isfinite(res.x).all())
+
+
+def test_linprog_simplex_workspaces():
+    c = np.array([1., 1.])
+    A_ub, b_ub = np.array([[1., 1.]]), np.array([1.])
+    A_eq, b_eq = np.array([[1., -1.]]), np.array([0.])
+    n, m, k = 2, 1, 1
+    L = m + k
+    res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                          tableau=np.empty((L+1, n+m+L+1)),
+                          basis=np.empty(L, dtype=int),
+                          x=np.empty(n), lambd=np.empty(L))
+    assert_(res.success)
+    assert_allclose(res.x, [0.5, 0.5])

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -251,3 +251,15 @@ class TestLinprogSimplex:
         desired_x = [0.1, 0]
         res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
         _assert_success(res, c, b_ub=b_ub, desired_x=desired_x)
+
+    def test_lex_tie_is_not_unbounded(self):
+        # maximize x subject to 1e14*x <= 0 (twice) and x >= 0, so that
+        # x = 0 is the unique feasible, hence optimal, solution. The two
+        # constraint rows tie in the lexico-minimum ratio test in all
+        # columns within `tol_ratio_diff`, which used to be reported as
+        # "unbounded".
+        c = np.array([1.])
+        A_ub = np.array([[1e14], [1e14]])
+        b_ub = np.zeros(2)
+        res = linprog_simplex(c, A_ub=A_ub, b_ub=b_ub)
+        _assert_success(res, c, b_ub=b_ub, desired_fun=0., desired_x=[0.])

--- a/quantecon/optimize/tests/test_linprog_simplex.py
+++ b/quantecon/optimize/tests/test_linprog_simplex.py
@@ -311,6 +311,17 @@ class TestLinprogSimplexPhase1Scale:
         assert_(res.status == 0)
         assert_allclose(res.fun, -1e5, atol=1e-3)
 
+    def test_infeasible_in_a_small_constraint(self):
+        # x1 = 1e6, x2 = 0 and x2 = 0.9: the contradiction of 0.9 in a
+        # small constraint is below fea_tol times the scale of the whole
+        # right hand side, but not below fea_tol times its own scale
+        c = np.array([-1., -1.])
+        A_eq = np.array([[1., 0.], [0., 1.], [0., 1.]])
+        b_eq = np.array([1e6, 0., 0.9])
+        res = linprog_simplex(c, A_eq=A_eq, b_eq=b_eq)
+        assert_(not res.success)
+        assert_(res.status == 2)
+
     def test_infeasible_at_unit_scale(self):
         # The same inconsistency at scale 1 is infeasible
         c = np.array([-1., -1.])

--- a/quantecon/optimize/tests/test_pivoting.py
+++ b/quantecon/optimize/tests/test_pivoting.py
@@ -3,9 +3,9 @@ Tests for pivoting.py
 
 """
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_, assert_array_equal
 
-from quantecon.optimize.pivoting import _pivoting
+from quantecon.optimize.pivoting import _pivoting, _lex_min_ratio_test
 
 
 def _pivoting_reference(tableau, pivot_col, pivot_row):
@@ -48,3 +48,24 @@ class TestPivoting:
         tableau = np.array([[p, p, 0.], [p, 2*p, p]])
         _pivoting(tableau, 0, 0)
         assert_array_equal(tableau, np.array([[1., 1., 0.], [0., p, p]]))
+
+
+class TestLexMinRatioTest:
+    def test_unresolved_tie_is_found(self):
+        # Two identical rows: the ratios tie in the rhs column and, with
+        # entries of order 1e14, also in all the slack columns within
+        # `tol_ratio_diff`. The pivot column has positive entries, so the
+        # row must be reported as found.
+        tableau = np.array([[1e14, 1., 0., 0.],
+                            [1e14, 0., 1., 0.]])
+        argmins = np.empty(2, dtype=np.int_)
+        found, row = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        assert_(found)
+        assert_(row in (0, 1))
+
+    def test_no_positive_entry_is_not_found(self):
+        tableau = np.array([[-1., 1., 0., 1.],
+                            [0., 0., 1., 1.]])
+        argmins = np.empty(2, dtype=np.int_)
+        found, _ = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        assert_(not found)

--- a/quantecon/optimize/tests/test_pivoting.py
+++ b/quantecon/optimize/tests/test_pivoting.py
@@ -5,7 +5,9 @@ Tests for pivoting.py
 import numpy as np
 from numpy.testing import assert_, assert_array_equal
 
-from quantecon.optimize.pivoting import _pivoting, _lex_min_ratio_test
+from quantecon.optimize.pivoting import (
+    _pivoting, _lex_min_ratio_test, _min_ratio_test_no_tie_breaking
+)
 
 
 def _pivoting_reference(tableau, pivot_col, pivot_row):
@@ -83,6 +85,25 @@ class TestLexMinRatioTest:
         assert_(found)
         assert_(row == 1)
         assert_(resolved)
+
+    def test_ties_measured_against_the_minimum(self):
+        # Ratios -3.00, -3.09, -2.91 with tolerance 0.1: the second is
+        # within the tolerance of the first, the third within the
+        # tolerance of the first but not of the minimum (the second), so
+        # the candidates must be the first two rows only
+        tableau = np.array([[1., 1., 0., 0., -3.00],
+                            [1., 0., 1., 0., -3.09],
+                            [1., 0., 0., 1., -2.91]])
+        argmins = np.arange(3)
+        num_argmins = _min_ratio_test_no_tie_breaking(
+            tableau, 0, -1, argmins, 3, 1e-7, 0.1
+        )
+        assert_(num_argmins == 2)
+        assert_(set(argmins[:2]) == {0, 1})
+        found, row, resolved = _lex_min_ratio_test(tableau, 0, 1, argmins,
+                                                   1e-7, 0.1)
+        assert_(found and resolved)
+        assert_(row == 1)
 
     def test_no_positive_entry_is_not_found(self):
         tableau = np.array([[-1., 1., 0., 1.],

--- a/quantecon/optimize/tests/test_pivoting.py
+++ b/quantecon/optimize/tests/test_pivoting.py
@@ -59,13 +59,35 @@ class TestLexMinRatioTest:
         tableau = np.array([[1e14, 1., 0., 0.],
                             [1e14, 0., 1., 0.]])
         argmins = np.empty(2, dtype=np.int_)
-        found, row = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        found, row, resolved = _lex_min_ratio_test(tableau, 0, 1, argmins,
+                                                   1e-7, 1e-13)
         assert_(found)
         assert_(row in (0, 1))
+        assert_(not resolved)
+
+    def test_unique_row_is_resolved(self):
+        tableau = np.array([[1., 1., 0., 2.],
+                            [1., 0., 1., 1.]])
+        argmins = np.empty(2, dtype=np.int_)
+        found, row, resolved = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        assert_(found)
+        assert_(row == 1)
+        assert_(resolved)
+
+    def test_tie_broken_lexicographically(self):
+        # Equal ratios in the rhs column; the slack columns break the tie
+        tableau = np.array([[1., 1., 0., 1.],
+                            [1., 0., 1., 1.]])
+        argmins = np.empty(2, dtype=np.int_)
+        found, row, resolved = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        assert_(found)
+        assert_(row == 1)
+        assert_(resolved)
 
     def test_no_positive_entry_is_not_found(self):
         tableau = np.array([[-1., 1., 0., 1.],
                             [0., 0., 1., 1.]])
         argmins = np.empty(2, dtype=np.int_)
-        found, _ = _lex_min_ratio_test(tableau, 0, 1, argmins)
+        found, _, resolved = _lex_min_ratio_test(tableau, 0, 1, argmins)
         assert_(not found)
+        assert_(not resolved)

--- a/quantecon/tests/test_compute_fp.py
+++ b/quantecon/tests/test_compute_fp.py
@@ -9,6 +9,7 @@ https://www.math.ucdavis.edu/~hunter/book/ch3.pdf
 TODO: add multivariate case
 
 """
+import warnings
 import numpy as np
 from numpy.testing import assert_, assert_raises
 from quantecon import compute_fixed_point
@@ -133,3 +134,30 @@ def test_raises_value_error_nonpositive_max_iter():
     init = 1.
     max_iter = 0
     assert_raises(ValueError, compute_fixed_point, f, init, max_iter=max_iter)
+
+
+def test_imitation_game_numerical_breakdown():
+    # Values of order 1e7: the Lemke-Howson pivoting on the imitation
+    # game breaks down numerically (the tableaux hold no equilibrium);
+    # the routine must stop and report non-convergence, with a specific
+    # warning, instead of forming the next iterate from the tableaux
+    X = np.array([-43904436.689917795, -58130594.69589446,
+                  -51017515.692906134])
+    Y = np.array([-58130594.69589446, 73372551.04835357,
+                  45264022.10520259])
+    max_iter = 10
+    evaluations = []
+
+    def T(x):  # Map reproducing the sequence: nearest recorded point
+        evaluations.append(x)
+        return Y[np.argmin(np.abs(X - x))]
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        x = compute_fixed_point(T, X[0], error_tol=1e-3, max_iter=max_iter,
+                                verbose=1, method='imitation_game')
+    messages = [str(wi.message) for wi in w]
+    assert_(any('numerical breakdown' in msg for msg in messages))
+    assert_(not any('max_iter' in msg for msg in messages))
+    assert_(len(evaluations) < max_iter)  # Stopped at the breakdown
+    assert_(np.isfinite(x))


### PR DESCRIPTION
Fixes to the pivoting routines and their callers, found while benchmarking `linprog_simplex` on the Netlib problems.

- `_lex_min_ratio_test`: `found=False` was returned both when the pivot column has no positive entry and when the lexicographic tie breaking failed to single out one row; the latter was reported as "unbounded" by `linprog_simplex`. Return `found=True` with the first candidate in that case, together with a third value `resolved`.
- `lemke_howson` and `polym_lcp_solver` discarded `found`; they now stop with `converged=False` on breakdown instead of returning a wrong "equilibrium".
- `lcp_lemke`: require `d > 0`; measure ties in the initial ratio test against the minimum ratio.
- `linprog_simplex`: `fun = inf` when unbounded; Phase 1 infeasibility test relative to the scale of `b`; pivot artificial variables out on the largest entry; docstring fixes.
- Guard docstring formatting against `python -OO`, which made `quantecon` unimportable.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
