### PR TITLE
WASM: document platform-dependent intp overflow boundary (#929)

### DIFF
--- a/quantecon/_gridtools.py
+++ b/quantecon/_gridtools.py
@@ -293,6 +293,13 @@ def simplex_grid(m, n):
     A grid of the (m-1)-dimensional *unit* simplex with n subdivisions
     along each dimension can be obtained by `simplex_grid(m, n) / n`.
 
+    The maximum grid size L is bounded by ``np.iinfo(np.intp).max``, which
+    is platform-dependent: 2³¹−1 on wasm32 (JupyterLite/xeus-python) and
+    2⁶³−1 on 64-bit platforms. Inputs that would produce a larger L raise
+    ``ValueError``. With ``m >= 2``, the wasm32 limit is reached only for
+    grids that would require ≥ 16 GB of memory, far exceeding the wasm32
+    address space.
+
     Examples
     --------
     >>> simplex_grid(3, 4)
@@ -430,6 +437,12 @@ def num_compositions_jit(m, n):
     """
     Numba jit version of `num_compositions`. Return `0` if the outcome
     exceeds the maximum value of `np.intp`.
+
+    Notes
+    -----
+    The overflow boundary ``np.iinfo(np.intp).max`` is platform-dependent:
+    2³¹−1 on wasm32 (JupyterLite/xeus-python) and 2⁶³−1 on 64-bit
+    platforms.
 
     """
     return comb_jit(n+m-1, m-1)

--- a/quantecon/util/combinatorics.py
+++ b/quantecon/util/combinatorics.py
@@ -112,7 +112,9 @@ def k_array_rank_jit(a):
     responsibility to ensure that the rank of the input array fits
     within the range of possible values of `np.intp`; a sufficient
     condition for it is `scipy.special.comb(a[-1]+1, len(a), exact=True)
-    <= np.iinfo(np.intp).max`.
+    <= np.iinfo(np.intp).max`. The bound ``np.iinfo(np.intp).max`` is
+    platform-dependent: 2³¹−1 on wasm32 (JupyterLite/xeus-python) and
+    2⁶³−1 on 64-bit platforms.
 
     """
     k = len(a)

--- a/quantecon/util/numba.py
+++ b/quantecon/util/numba.py
@@ -94,6 +94,13 @@ def comb_jit(N, k):
     -------
     val : scalar(int)
 
+    Notes
+    -----
+    The overflow boundary ``np.iinfo(np.intp).max`` is platform-dependent:
+    2³¹−1 on wasm32 (JupyterLite/xeus-python) and 2⁶³−1 on 64-bit
+    platforms. The result is an array size or rank, so ``np.intp`` is the
+    correct width on every platform.
+
     """
     # From scipy.special._comb_int_long
     # github.com/scipy/scipy/blob/v1.0.0/scipy/special/_comb.pyx


### PR DESCRIPTION
Closes #929.

Documents the `np.iinfo(np.intp).max` overflow boundary in `comb_jit`, `num_compositions_jit`, `simplex_grid`, and `k_array_rank_jit`, noting it is 2³¹−1 on wasm32 (JupyterLite) vs 2⁶³−1 on 64-bit platforms. No code changes.

Grep sweep of all `intp`/`int_` sites in the library confirms every use is an index or array size — none need widening to `int64`.