### PR TITLE
DEPR: deprecate fetch_nb_dependencies and demote requests to an extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,15 @@ requires-python = ">=3.7"
 dependencies = [
     'numba>=0.56.0',
     'numpy>=1.17.0',
-    'requests',
     'scipy>=1.5.0',
 ]
 
 [project.optional-dependencies]
+# Supports the deprecated quantecon.util.notebooks helpers; removed in v1.0
+# together with the module itself.
+notebooks = [
+    "requests",
+]
 testing = [
     "pytest",
     "coverage",

--- a/quantecon/util/notebooks.py
+++ b/quantecon/util/notebooks.py
@@ -11,15 +11,18 @@ when downloaded as a support File
 
 "https://github.com/QuantEcon/QuantEcon.notebooks/raw/master/dependencies/mpi/something.py" --> ./something.py
 
-TODO
-----
-1. Write Style guide for QuantEcon.notebook contributions
-2. Write an interface for Dat Server
-3. Platform Agnostic (replace wget usage)
+.. deprecated:: 0.12.0
+    ``fetch_nb_dependencies`` is deprecated and will be removed in v1.0, along
+    with this module. It has no remaining callers in the QuantEcon lecture
+    series, and ``requests`` is no longer a mandatory dependency of
+    QuantEcon.py. Datasets referenced by the lectures live in
+    `QuantEcon/data-lectures <https://github.com/QuantEcon/data-lectures>`_ and
+    should be fetched by stable URL with the tool of your choice.
 
 """
 
 import os
+import warnings
 
 #-Remote Structure-#
 REPO = "https://github.com/QuantEcon/QuantEcon.notebooks"
@@ -32,6 +35,11 @@ FOLDER = "dependencies"
 def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDER, overwrite=False, verbose=True):
     """
     Retrieve raw files from QuantEcon.notebooks or other Github repo
+
+    .. deprecated:: 0.12.0
+        Deprecated and will be removed in v1.0. Fetch data by stable URL from
+        `QuantEcon/data-lectures <https://github.com/QuantEcon/data-lectures>`_
+        instead.
     
     Parameters
     ----------
@@ -71,7 +79,22 @@ def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDE
     by setting ``overwrite=True``.
 
     """
-    import requests
+    warnings.warn(
+        "`fetch_nb_dependencies` is deprecated and will be removed in v1.0. "
+        "Fetch data by stable URL from QuantEcon/data-lectures instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    try:
+        import requests
+    except ImportError:                                   # pragma: no cover
+        raise ImportError(
+            "`fetch_nb_dependencies` requires `requests`, which is no longer a "
+            "mandatory dependency of QuantEcon.py. Install it with "
+            "`pip install 'quantecon[notebooks]'`. This function is deprecated "
+            "and will be removed in v1.0."
+        )
 
     #-Generate Common Data Structure-#
     if type(files) == list:
@@ -99,6 +122,8 @@ def fetch_nb_dependencies(files, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDE
             #-Get file in OS agnostic way using requests-#
             url = "/".join([repo, raw, branch, folder, fl])
             r = requests.get(url)
+            #-Do not write an error page to disk under the requested name (#870)-#
+            r.raise_for_status()
             with open(fl, "wb") as fl:
                 fl.write(r.content)
             status.append(True)

--- a/quantecon/util/tests/test_notebooks.py
+++ b/quantecon/util/tests/test_notebooks.py
@@ -9,6 +9,7 @@ fetch_nb_dependencies
 
 from quantecon.util import fetch_nb_dependencies
 import os
+import pytest
 
 FILES = ['test_file.md']
 REPO = "https://github.com/QuantEcon/QuantEcon.py"
@@ -17,6 +18,7 @@ BRANCH = "main"
 FOLDER = "quantecon/util/tests/"
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestNotebookUtils:
 
     def test_fetch_nb_dependencies(self):
@@ -39,3 +41,16 @@ class TestNotebookUtils:
 
     def teardown_method(self):
         os.remove("test_file.md")
+
+
+class TestNotebookUtilsDeprecation:
+    """`fetch_nb_dependencies` is deprecated in 0.12.0 and removed in v1.0."""
+
+    def test_fetch_nb_dependencies_warns(self):
+        with pytest.warns(DeprecationWarning, match="removed in v1.0"):
+            fetch_nb_dependencies(
+                files=FILES, repo=REPO, raw=RAW, branch=BRANCH, folder=FOLDER)
+
+    def teardown_method(self):
+        if os.path.isfile("test_file.md"):
+            os.remove("test_file.md")


### PR DESCRIPTION
Retires `quantecon/util/notebooks.py`: deprecated in 0.12.0, removed in v1.0, with `requests` moved out of the mandatory dependency set at the same time.

## Why

`requests` is a hard runtime dependency of QuantEcon.py that serves exactly one call site — `fetch_nb_dependencies` — and nothing else in the package imports it. That function has no remaining constituency:

| Evidence | Finding |
| --- | --- |
| Lecture repositories | No usage in `lecture-python.myst`, `lecture-python-advanced.myst`, `lecture-python-intro` or `lecture-python-programming.myst` |
| Callers found by code search | Dormant notebooks descending from two 2017-era demos (`Wald_Friedman`, `von_neumann`) |
| Default remote | `QuantEcon/QuantEcon.notebooks`, last pushed 2023-07-15 |
| Known defects | Four in ~30 lines, catalogued in #870 |

Datasets the lectures depend on belong in [QuantEcon/data-lectures](https://github.com/QuantEcon/data-lectures), the canonical home for data referenced by stable URL. This is the retirement branch #880 anticipated for `requests`: move it behind an extra "or, if `fetch_nb_dependencies` has no remaining constituency, fold its retirement into the #786 utility-deprecation conversation". That condition is now tested and met, so this lands in the same release as #833's timer deprecations.

## Changes

- `.. deprecated:: 0.12.0` directives on the module and the function, replacing the stale 2016 TODO block that no longer described the code
- A `DeprecationWarning` at call time, `stacklevel=2` so it is attributed to the caller's frame
- `requests` moved from `dependencies` to a `notebooks` optional group; the lazy import now raises an `ImportError` naming `pip install 'quantecon[notebooks]'`
- `r.raise_for_status()` as harm reduction for the module's final release — see below
- A test asserting the warning fires; the existing tests carry `filterwarnings("ignore::DeprecationWarning")`

## On the `raise_for_status` line

#870 reported that a missing remote path saved GitHub's 404 HTML page under the requested filename and reported success — a 314 KB HTML document written as your `.csv`, with `True` in the status list. Since the function keeps working for one more release, it should not corrupt data while it does. Verified against the reported reproducer:

```
before:  returned [True]   file written (404 HTML body on disk)
after:   raises HTTPError  no file written
```

The other three defects in #870 (no timeout, the file handle shadowing the loop variable, `type(files) == list`) are deliberately left unfixed — the function is scheduled for removal, and #905 and #904 were closed on that basis.

## Verification

- Full suite: 679 passed
- `flake8 --select=F401,F405,E231 quantecon`: clean
- `git diff --check`: clean
- Deprecation warning confirmed attributed to the caller's frame, not `notebooks.py`
- Missing-`requests` path confirmed to raise the `ImportError` naming the extra
- CI unaffected: `environment.yml` lists `requests` and `urllib3>=2` explicitly, so the test environment keeps them while the module exists

## Follow-ups

- `requests` and `urllib3` come out of `environment.yml` when the module is removed in v1.0 — tracked separately
- The `sympy` half of #880 landed in #947; this closes the `requests` half

Part of #880. Supersedes #870, #904 and #905, all closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
