### PR TITLE
FIX: align draw's Python size dispatch with the jitted path (#918)

### DIFF
--- a/quantecon/random/tests/test_utilities.py
+++ b/quantecon/random/tests/test_utilities.py
@@ -125,6 +125,17 @@ class TestDraw:
             out = func(self.cdf, size)
             assert_(out.shape == (size,))
 
+    def test_numpy_integer_size(self):
+        """
+        A numpy integer `size` must request an array, as a Python `int`
+        does and as the jitted path already did. See #918.
+
+        """
+        size = np.int64(10)
+        for func in self.draw_funcs:
+            out = func(self.cdf, size)
+            assert_(out.shape == (size,))
+
     def test_return_values(self):
         for func in self.draw_funcs:
             out = func(self.cdf)

--- a/quantecon/random/utilities.py
+++ b/quantecon/random/utilities.py
@@ -246,7 +246,10 @@ def draw(cdf, size=None, rng=None):
     """
     if rng is None:
         rng = np.random
-    if isinstance(size, int):
+    # `bool` subclasses `int` in Python but Numba types it as `Boolean`,
+    # not `Integer`, so the exclusion keeps this branch in step with the
+    # `@overload` implementation below. See #918.
+    if isinstance(size, (int, np.integer)) and not isinstance(size, bool):
         rs = rng.random(size)
         out = np.searchsorted(cdf, rs, side='right')
         return out


### PR DESCRIPTION
Aligns the Python `size` dispatch in `quantecon.random.draw` with the jitted path. Replaces #919, which was closed with thanks; this is the reduced form of the same fix.

## The bug

`draw` decides between "an array of `size` draws" and "one scalar draw" in two places, with two tests that do not agree:

| Path | Test |
| --- | --- |
| Pure Python body | `isinstance(size, int)` |
| `@overload` implementation | `isinstance(size, types.Integer)` |

A NumPy integer is not a Python `int` but *is* a `types.Integer`, so the same call returns different things depending on whether the call site is jit-compiled — and nothing warns. This is easy to hit: `size` arrives as `np.int64` from any ordinary numpy expression (`counts[i]`, `arr.sum()`, `arr.argmax()`, a `//` on an array), while `len(x)` and `arr.shape[0]` give Python ints and are fine, which is why it survives casual testing.

## The change

One line in the Python body, plus the comment explaining it:

```python
if isinstance(size, (int, np.integer)) and not isinstance(size, bool):
```

The `bool` exclusion is required in the other direction: `bool` subclasses `int` in Python, but Numba types it as `Boolean`, so without it the two paths would still disagree for `size=True`.

**The `@overload` needs no change.** `types.Boolean` is not a subclass of `types.Integer`, so the jitted path already dispatches every case correctly — only the Python body was wrong.

## Verified

Dispatch table on this branch, Python against jitted, for every case in #918:

| `size` | Python | Jitted | |
| --- | --- | --- | --- |
| `10` | array(10,) | array(10,) | agree |
| `np.int64(10)` | array(10,) | array(10,) | agree |
| `np.int32(10)` | array(10,) | array(10,) | agree |
| `np.uint8(10)` | array(10,) | array(10,) | agree |
| `True` | scalar | scalar | agree |
| `np.bool_(True)` | scalar | scalar | agree |
| `10.0` | scalar | scalar | agree |
| `None` | scalar | scalar | agree |

`None` was checked across all four call shapes — omitted and explicit, from Python and from a jitted caller — since `_is_no_rng` shows Numba spells "no value" more than one way.

- Full suite: 679 passed
- `flake8 --select=F401,F405,E231 quantecon`: clean
- `git diff --check`: clean

## Release note needed

`draw(cdf, np.int64(10))` now returns ten draws from Python where it previously returned one scalar. That is what the caller asked for, and what jitted callers already received, but it is a silent behaviour change and should be called out in the 0.12.0 release notes. Per AGENTS.md there is no per-PR changelog entry to add.

Closes #918. Replaces #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
