### PR TITLE
TST: Cover the multi-distribution branch in test_left_eigen_vec

### DIFF
--- a/quantecon/markov/tests/test_core.py
+++ b/quantecon/markov/tests/test_core.py
@@ -178,30 +178,17 @@ def test_markovchain_pmatrices():
 # Basic Class Structure with Setup #
 ####################################
 
-class Test_markovchain_stationary_distributions_KMRMarkovMatrix2():
+class _Test_markovchain_stationary_distributions_Base():
     """
-    Test Suite for MarkovChain.stationary_distributions using KMR Markov
-    Matrix [suitable for nose]
+    Shared test suite for MarkovChain.stationary_distributions. Concrete
+    subclasses provide `setup_method`, which must set `self.mc`,
+    `self.stationary` (`self.mc.stationary_distributions`) and
+    `self.n_stat_dists` (the number of stationary distributions), so that
+    both the single- and multiple-stationary-distribution cases are
+    exercised by `test_left_eigen_vec`.
     """
 
-    # Starting Values #
-
-    N = 27
-    epsilon = 1e-2
-    p = 1/3
     TOL = 1e-2
-
-    def setup_method(self):
-        """ Setup a KMRMarkovMatrix and Compute Stationary Values """
-        self.P = KMR_Markov_matrix_sequential(self.N, self.p, self.epsilon)
-        self.mc = MarkovChain(self.P)
-        self.stationary = self.mc.stationary_distributions
-        stat_shape = self.stationary.shape
-
-        if len(stat_shape) == 1:
-            self.n_stat_dists = 1
-        else:
-            self.n_stat_dists = stat_shape[0]
 
     def test_markov_matrix(self):
         "Check that each row of matrix sums to 1"
@@ -231,6 +218,60 @@ class Test_markovchain_stationary_distributions_KMRMarkovMatrix2():
             for i in range(self.n_stat_dists):
                 curr_v = stationary_distributions[i, :]
                 assert_allclose(curr_v @ mc.P, curr_v, atol=self.TOL)
+
+
+class Test_markovchain_stationary_distributions_KMRMarkovMatrix2(
+        _Test_markovchain_stationary_distributions_Base):
+    """
+    Test Suite for MarkovChain.stationary_distributions using KMR Markov
+    Matrix [suitable for nose]
+
+    The KMR matrix is irreducible, so this suite only ever exercises the
+    single-stationary-distribution case (`n_stat_dists == 1`); see
+    Test_markovchain_stationary_distributions_ReducibleMarkovMatrix below
+    for the multiple-stationary-distribution case.
+    """
+
+    # Starting Values #
+
+    N = 27
+    epsilon = 1e-2
+    p = 1/3
+
+    def setup_method(self):
+        """ Setup a KMRMarkovMatrix and Compute Stationary Values """
+        self.P = KMR_Markov_matrix_sequential(self.N, self.p, self.epsilon)
+        self.mc = MarkovChain(self.P)
+        self.stationary = self.mc.stationary_distributions
+        # stationary_distributions is always 2-dimensional, of shape
+        # (n_stat_dists, mc.n)
+        self.n_stat_dists = self.stationary.shape[0]
+
+
+class Test_markovchain_stationary_distributions_ReducibleMarkovMatrix(
+        _Test_markovchain_stationary_distributions_Base):
+    """
+    Test Suite for MarkovChain.stationary_distributions using a reducible
+    matrix with two recurrent classes (two absorbing states, reached from
+    two transient states), so that `n_stat_dists > 1` and the
+    multiple-stationary-distribution branch of test_left_eigen_vec is
+    exercised.
+    """
+
+    # States 0 and 1 are absorbing (each its own recurrent class); states 2
+    # and 3 are transient.
+    P = np.array([[1.0, 0.0, 0.0, 0.0],
+                  [0.0, 1.0, 0.0, 0.0],
+                  [0.3, 0.3, 0.4, 0.0],
+                  [0.0, 0.2, 0.0, 0.8]])
+
+    def setup_method(self):
+        """ Setup the reducible MarkovChain and Compute Stationary Values """
+        self.mc = MarkovChain(self.P)
+        self.stationary = self.mc.stationary_distributions
+        # stationary_distributions is always 2-dimensional, of shape
+        # (n_stat_dists, mc.n)
+        self.n_stat_dists = self.stationary.shape[0]
 
 
 def test_simulate_shape():


### PR DESCRIPTION
## What was wrong

`Test_markovchain_stationary_distributions_KMRMarkovMatrix2` in
`quantecon/markov/tests/test_core.py` only ever used the irreducible KMR
sequential-move matrix (`N = 27`), which has exactly one stationary
distribution. Because of that:

- The `else` branch of `test_left_eigen_vec` (the multiple-stationary-
  distributions case) was never executed by the suite.
- The `if len(stat_shape) == 1:` arm in `setup_method` was similarly dead,
  since `MarkovChain.stationary_distributions` is documented as always
  `ndim=2`, so `stat_shape` always has length 2.

Both branches were correct code, just untested code masquerading as tested.

## What changed

- Factored the four existing test methods (`test_markov_matrix`,
  `test_sum_one`, `test_nonnegative`, `test_left_eigen_vec`) out into a
  shared, non-collected base class `_Test_markovchain_stationary_distributions_Base`.
- Kept `Test_markovchain_stationary_distributions_KMRMarkovMatrix2` as a
  subclass with the exact same `N=27` KMR matrix, `setup_method` logic, and
  assertions as before (only the dead `if len(stat_shape) == 1` arm was
  removed, since it can never be reached).
- Added a new subclass, `Test_markovchain_stationary_distributions_ReducibleMarkovMatrix`,
  built on a reducible 4-state matrix with two absorbing states (states 0
  and 1) reached from two transient states (2 and 3). This gives
  `stationary_distributions.shape == (2, 4)`, so `n_stat_dists == 2` and the
  `else` branch of `test_left_eigen_vec` is now actually exercised and
  verified.

No production code in `quantecon/markov/core.py` changed; this is a
test-only fix, matching the "TST:" convention used for the issue.

## How it was verified

```
python -m pytest quantecon/markov/tests/test_core.py -v
# 36 passed
```

To prove the previously-dead `else` branch is now hit, a temporary print
was added inside the `else` branch of `test_left_eigen_vec` and run with
`pytest -k test_left_eigen_vec -s`:

```
Test_markovchain_stationary_distributions_KMRMarkovMatrix2::test_left_eigen_vec PASSED
Test_markovchain_stationary_distributions_ReducibleMarkovMatrix::test_left_eigen_vec TEMP-COVERAGE-PROBE: else branch hit, n_stat_dists= 2
PASSED
```

confirming the KMR case takes the `if` branch (`n_stat_dists == 1`, no
print) and the new reducible-matrix case takes the `else` branch with
`n_stat_dists == 2`. The temporary print was removed before the final
commit (`pytest-cov`/`coverage.py` could not be used for this in the local
dev environment — both hit an unrelated `ImportError: cannot load module
more than once per process` from numpy 2.x's C-extension guard when
combined with coverage's import hooks on this machine).

```
flake8 --select=F401,F405,E231 quantecon/markov/tests/test_core.py
# clean, no output
```

Fixes #961